### PR TITLE
ISS6411: Refactored cacheAsset handling to remove redundant S3 call

### DIFF
--- a/lambda/assets/dataSource/caching/cacheAsset.test.ts
+++ b/lambda/assets/dataSource/caching/cacheAsset.test.ts
@@ -152,7 +152,7 @@ describe('Cache Asset (Data Source)', () => {
     })
 
     describe('Address handling', () => {
-        it('should not cache when address is missing', async () => {
+        it('should throw error when zone is missing', async () => {
             // Mock empty dbAsset
             internalCacheMock.AssetData.get.mockResolvedValue([{
                 AssetId: 'ASSET#primitives',
@@ -165,7 +165,7 @@ describe('Cache Asset (Data Source)', () => {
                 zone: undefined
             }])
 
-            await cacheAsset({ assetId: 'primitives', streamEvent: mockStreamEvent })
+            await expect(cacheAsset({ assetId: 'primitives', streamEvent: mockStreamEvent })).rejects.toThrow('cacheAsset: Missing zone')
 
             // Should not call putItem or optimisticUpdate
             expect(assetDBMock.putItem).not.toHaveBeenCalled()

--- a/lambda/assets/dataSource/caching/cacheAsset.ts
+++ b/lambda/assets/dataSource/caching/cacheAsset.ts
@@ -5,6 +5,7 @@ import { StandardRemove } from "@tonylb/mtw-wml/ts/standardize/components/edits"
 import { assetDB } from "@tonylb/mtw-utilities/ts/dynamoDB";
 import { AssetKey } from "@tonylb/mtw-utilities/ts/types";
 import { AssetsEventUpdate, ComponentUpdatedEvent } from '@tonylb/mtw-interfaces/ts/eventBridge/assets';
+import { Zone } from '@tonylb/mtw-interfaces/ts/baseClasses';
 
 /**
  * Cache asset content to DynamoDB storage
@@ -12,10 +13,7 @@ import { AssetsEventUpdate, ComponentUpdatedEvent } from '@tonylb/mtw-interfaces
  * This function synchronizes asset content between S3 files and DynamoDB storage,
  * identifying and applying only changed components for efficient updates.
  * 
- * @param params - Parameters object
- * @param params.assetId - The asset ID to cache
- * @param params.streamEvent - Function to stream events to EventBridge and messageBus subscribers
- * @returns Promise<void>
+ * Returns the zone/player used for streaming, and whether this is a new asset.
  */
 export const cacheAsset = async ({ assetId, streamEvent }: {
     assetId: string;
@@ -23,10 +21,10 @@ export const cacheAsset = async ({ assetId, streamEvent }: {
         update: AssetsEventUpdate;
         streamKey: string;
     }) => Promise<void>;
-}): Promise<void> => {
+}): Promise<{ zone: Zone; player?: string; isNewAsset: boolean }> => {
     const assetUUID = AssetKey(assetId)
 
-    const [dbAsset, { assetWorkspace, standardForm: fileAsset }] = await Promise.all([
+    const [dbAsset, { assetWorkspace, standardForm: fileAsset }, priorMeta] = await Promise.all([
         internalCache.AssetData.get([assetUUID]).then(([assetCache]) => (assetCache?.standardForm ?? new StandardForm(`<Asset uuid=(${assetId}) />`))),
         (async () => {
             const assetWorkspace = await ReadOnlyAssetWorkspace.fromUUID(assetUUID, { allowS3Fallback: true })
@@ -35,11 +33,20 @@ export const cacheAsset = async ({ assetId, streamEvent }: {
             }
             await assetWorkspace.loadJSON()
             return { assetWorkspace, standardForm: assetWorkspace.standard ?? new StandardForm(assetUUID) }
-        })()
+        })(),
+        assetDB.getItem({
+            Key: {
+                AssetId: assetUUID,
+                DataCategory: 'Meta::Asset'
+            },
+            ProjectionFields: ['AssetId']
+        })
     ])
 
     const diff = dbAsset.diff(fileAsset)
-    
+
+    const isNewAsset = !(priorMeta && (priorMeta as any).AssetId)
+
     // Phase 1B: Parallelize Meta::Asset write with component updates for efficiency
     // Replaces old dbRegister function with minimal, focused metadata write
     const metaAssetWrite = (async () => {
@@ -61,11 +68,12 @@ export const cacheAsset = async ({ assetId, streamEvent }: {
                 // Note: No import graph maintenance (deferred to component-level redesign)
             })
         }
+        return { zone, player }
     })()
     
     if (diff) {
-        await Promise.all([
-            metaAssetWrite,
+        const [metaResult] = await Promise.all([
+            metaAssetWrite as Promise<{ zone?: string; player?: string }>,
             ...diff._components
             .map(async (component) => {
                 if (!component.universalKey) {
@@ -162,8 +170,17 @@ export const cacheAsset = async ({ assetId, streamEvent }: {
                 streamKey: assetId
             })
         }
+
+        if (!metaResult.zone) {
+            throw new Error(`cacheAsset: Missing zone for asset ${assetId}`)
+        }
+        return { zone: metaResult.zone as Zone, player: metaResult.player, isNewAsset }
     } else {
         // Even with no diff, write Meta::Asset record
-        await metaAssetWrite
+        const metaResult = await metaAssetWrite
+        if (!metaResult.zone) {
+            throw new Error(`cacheAsset: Missing zone for asset ${assetId}`)
+        }
+        return { zone: metaResult.zone as Zone, player: metaResult.player, isNewAsset }
     }
 }

--- a/lambda/assets/dataSource/index.test.ts
+++ b/lambda/assets/dataSource/index.test.ts
@@ -8,7 +8,7 @@ import { schemaToWML } from '@tonylb/mtw-wml/ts/schema'
 import { StandardRemove } from '@tonylb/mtw-wml/ts/standardize/components/edits'
 import { deIndentWML } from '@tonylb/mtw-wml/ts/schema/utils'
 import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'
-import { decacheAsset } from './caching'
+import { cacheAsset, decacheAsset } from './caching'
 
 // Mock external dependencies
 jest.mock('@tonylb/mtw-utilities/ts/dynamoDB', () => ({
@@ -47,11 +47,16 @@ jest.mock('./caching')
 
 const assetDBMock = jest.mocked(assetDB, { shallow: false })
 const eventBridgeSendMock = jest.mocked(eventBridgeClient.send, { shallow: false })
+const cacheAssetMock = jest.mocked(cacheAsset)
 const decacheAssetMock = jest.mocked(decacheAsset)
 
 describe('AssetsDataSource (mtw.assets)', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        cacheAssetMock.mockResolvedValue({
+            zone: 'Library',
+            isNewAsset: false
+        } as any)
         decacheAssetMock.mockResolvedValue(undefined)
         // Mock assetDB.query for diagnostic tests
         assetDBMock.query.mockResolvedValue([])

--- a/lambda/assets/dataSource/index.ts
+++ b/lambda/assets/dataSource/index.ts
@@ -9,7 +9,7 @@ import { AssetsEventSerializer, AssetsEventUpdate } from '@tonylb/mtw-interfaces
 import { StreamingEventPayload } from '@tonylb/mtw-lambda-patterns/ts/dataSource/baseClasses'
 import { WMLEventUpdate } from '@tonylb/mtw-interfaces/ts/eventBridge/wml'
 import { AssetUUID } from "@tonylb/mtw-base/ts/schema"
-import ReadOnlyAssetWorkspace from "@tonylb/mtw-asset-workspace/ts/readOnly"
+
 
 // Separate type for WML events with precise typing
 type WMLSubscribedEvent = StreamingEventPayload & {
@@ -72,23 +72,7 @@ export const assetsDataSource = new AssetsDataSource<never, AssetsEventUpdate, A
                 const assetId = event.streamKey as AssetUUID
                 if (assetId) {
                     try {
-                        // Check if this is a new asset (for Asset Added event)
-                        const priorMeta = await assetDB.getItem({
-                            Key: {
-                                AssetId: assetId,
-                                DataCategory: 'Meta::Asset'
-                            },
-                            ProjectionFields: ['AssetId']
-                        })
-                        const isNewAsset = !(priorMeta && priorMeta.AssetId)
-                        
-                        // Load workspace to get fresh zone/player (Content Update events don't include this)
-                        // This avoids cache timing issues since cacheAsset writes metadata asynchronously
-                        const assetWorkspace = await ReadOnlyAssetWorkspace.fromUUID(assetId, { allowS3Fallback: true })
-                        const zone = assetWorkspace?.zone || 'Unknown'
-                        const player = assetWorkspace?.player
-                        
-                        await cacheAsset({ assetId, streamEvent })
+                        const { zone, player, isNewAsset } = await cacheAsset({ assetId, streamEvent })
                         
                         // Emit Asset Added event for new assets (before Asset Cached)
                         // Consumed by mtw.assets.library DataSource for automatic Library cache updates


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> cacheAsset now returns zone/player/isNewAsset and enforces zone presence; assetsDataSource uses this to emit Asset Added/Cached without redundant lookups.
> 
> - **Backend (mtw.assets)**:
>   - **cacheAsset** (`lambda/assets/dataSource/caching/cacheAsset.ts`):
>     - Returns `{ zone, player?, isNewAsset }`; determines new asset via `Meta::Asset` existence.
>     - Writes `Meta::Asset` (with optional `shortName`/`summary`) in parallel with component updates; throws if zone missing.
>     - Streams component updates and Asset-level metadata diffs; always writes Meta even with no component diff.
>   - **assetsDataSource** (`lambda/assets/dataSource/index.ts`):
>     - On `Content Update`, calls `cacheAsset` and emits `Asset Added` (if new) then `Asset Cached`, removing prior workspace/DB checks.
>   - **Tests**:
>     - Update mocks/usages to consume new `cacheAsset` return value and expect error when zone missing.
>     - Add/adjust assertions for Meta::Asset writes (including `shortName`/`summary`) and event emissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3caf4e9b5656cf1791d877e47d0ed3a2c3a9ea85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->