### PR TITLE
ISS6412: Removed redundant Snapshot Generated event message

### DIFF
--- a/charcoal-client/src/slices/dataSource/index.api.ts
+++ b/charcoal-client/src/slices/dataSource/index.api.ts
@@ -45,7 +45,7 @@ export const createInitializeAction = <SnapshotPayload, UpdatePayload>(
                     const { streamKey, timestamp, update } = payload
                     
                     // Route to appropriate processor based on message type
-                    if (update.type === 'Snapshot Generated') {
+                    if (update.type === 'Snapshot') {
                         dispatch(processRawSnapshot({ streamKey, timestamp, rawSnapshot: update }))
                     } else {
                         // All other update types are events

--- a/charcoal-client/src/slices/dataSource/index.test.ts
+++ b/charcoal-client/src/slices/dataSource/index.test.ts
@@ -5,7 +5,7 @@ import { DataSourceEventSerializer } from '@tonylb/mtw-lambda-patterns/ts/dataSo
 
 // Test types
 type TestSnapshot = {
-    type: 'Snapshot Generated'
+    type: 'Snapshot'
     value: number
 }
 
@@ -16,22 +16,22 @@ type TestUpdate = {
 type TestEvent = TestSnapshot | TestUpdate
 
 // Type guards
-const isTestSnapshot = (event: TestEvent): event is TestSnapshot => event.type === 'Snapshot Generated'
+const isTestSnapshot = (event: TestEvent): event is TestSnapshot => event.type === 'Snapshot'
 const isTestUpdate = (event: TestEvent): event is TestUpdate => event.type === 'Increment' || event.type === 'Decrement'
 
 // Mock aggregator
 const mockAggregator: DataSourceAggregator<TestSnapshot, TestUpdate> = {
-    createEmpty: () => ({ type: 'Snapshot Generated', value: 0 }),
+    createEmpty: () => ({ type: 'Snapshot', value: 0 }),
     applyUpdate: (snapshot, update) => {
         if (update.type === 'Increment') {
             return {
                 success: true,
-                snapshot: { type: 'Snapshot Generated', value: snapshot.value + 1 }
+                snapshot: { type: 'Snapshot', value: snapshot.value + 1 }
             }
         } else if (update.type === 'Decrement') {
             return {
                 success: true,
-                snapshot: { type: 'Snapshot Generated', value: snapshot.value - 1 }
+                snapshot: { type: 'Snapshot', value: snapshot.value - 1 }
             }
         }
         return {

--- a/charcoal-client/src/slices/dataSource/reducers.test.ts
+++ b/charcoal-client/src/slices/dataSource/reducers.test.ts
@@ -6,7 +6,7 @@ import { DataSourceEventSerializer } from '@tonylb/mtw-lambda-patterns/ts/dataSo
 
 // Test types
 type TestSnapshot = {
-    type: 'Snapshot Generated'
+    type: 'Snapshot'
     items: string[]
 }
 
@@ -18,19 +18,19 @@ type TestUpdate = {
 type TestEvent = TestSnapshot | TestUpdate
 
 // Type guards
-const isTestSnapshot = (event: TestEvent): event is TestSnapshot => event.type === 'Snapshot Generated'
+const isTestSnapshot = (event: TestEvent): event is TestSnapshot => event.type === 'Snapshot'
 const isTestUpdate = (event: TestEvent): event is TestUpdate => event.type === 'Item Added' || event.type === 'Item Removed'
 
 // Mock aggregator
 const mockAggregator: DataSourceAggregator<TestSnapshot, TestUpdate> = {
-    createEmpty: () => ({ type: 'Snapshot Generated', items: [] }),
+    createEmpty: () => ({ type: 'Snapshot', items: [] }),
     applyUpdate: (snapshot, update) => {
         try {
             if (update.type === 'Item Added') {
                 return {
                     success: true,
                     snapshot: {
-                        type: 'Snapshot Generated',
+                        type: 'Snapshot',
                         items: [...snapshot.items, update.item]
                     }
                 }
@@ -38,7 +38,7 @@ const mockAggregator: DataSourceAggregator<TestSnapshot, TestUpdate> = {
                 return {
                     success: true,
                     snapshot: {
-                        type: 'Snapshot Generated',
+                        type: 'Snapshot',
                         items: snapshot.items.filter(i => i !== update.item)
                     }
                 }
@@ -68,7 +68,7 @@ describe('dataSource reducers', () => {
         const applyEventsWithAggregator = applyEvents(mockAggregator)
         
         it('should apply multiple updates in order', () => {
-            const baseline: TestSnapshot = { type: 'Snapshot Generated', items: ['a'] }
+            const baseline: TestSnapshot = { type: 'Snapshot', items: ['a'] }
             const updates = [
                 { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 1000 },
                 { event: { type: 'Item Added' as const, item: 'c' }, timestamp: 2000 }
@@ -80,14 +80,14 @@ describe('dataSource reducers', () => {
         })
         
         it('should handle empty events array', () => {
-            const baseline: TestSnapshot = { type: 'Snapshot Generated', items: ['a'] }
+            const baseline: TestSnapshot = { type: 'Snapshot', items: ['a'] }
             const result = applyEventsWithAggregator(baseline, [])
             
             expect(result.items).toEqual(['a'])
         })
         
         it('should continue on aggregation failure', () => {
-            const baseline: TestSnapshot = { type: 'Snapshot Generated', items: ['a'] }
+            const baseline: TestSnapshot = { type: 'Snapshot', items: ['a'] }
             const updates = [
                 { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 1000 },
                 { event: { type: 'Invalid' as any, item: 'bad' }, timestamp: 2000 },  // This will fail
@@ -107,7 +107,7 @@ describe('dataSource reducers', () => {
         
         it('should keep all events when nothing is old', () => {
             const recentEvents = [
-                { event: { type: 'Snapshot Generated' as const, items: ['a'] }, timestamp: 50000 },
+                { event: { type: 'Snapshot' as const, items: ['a'] }, timestamp: 50000 },
                 { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 60000 }
             ]
             
@@ -115,13 +115,13 @@ describe('dataSource reducers', () => {
             
             // 30 seconds ago from 70000 is 40000, so all events are recent
             expect(result).toHaveLength(2)
-            expect(result[0].event).toEqual({ type: 'Snapshot Generated', items: ['a'] })
+            expect(result[0].event).toEqual({ type: 'Snapshot', items: ['a'] })
             expect(result[1].event).toEqual({ type: 'Item Added', item: 'b' })
         })
         
         it('should consolidate old events into synthetic snapshot', () => {
             const recentEvents = [
-                { event: { type: 'Snapshot Generated' as const, items: [] }, timestamp: 10000 },
+                { event: { type: 'Snapshot' as const, items: [] }, timestamp: 10000 },
                 { event: { type: 'Item Added' as const, item: 'a' }, timestamp: 20000 },
                 { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 30000 },
                 { event: { type: 'Item Added' as const, item: 'c' }, timestamp: 50000 }
@@ -137,7 +137,7 @@ describe('dataSource reducers', () => {
             
             // First event should be synthetic snapshot at 30-second boundary
             expect(result[0].timestamp).toBe(30000)
-            expect(result[0].event).toEqual({ type: 'Snapshot Generated', items: ['a', 'b'] })
+            expect(result[0].event).toEqual({ type: 'Snapshot', items: ['a', 'b'] })
             
             // Second event should be the recent event
             expect(result[1].timestamp).toBe(50000)
@@ -155,13 +155,13 @@ describe('dataSource reducers', () => {
             
             // Should create empty baseline and consolidate old events
             expect(result).toHaveLength(2)
-            expect(result[0].event).toEqual({ type: 'Snapshot Generated', items: ['a', 'b'] })
+            expect(result[0].event).toEqual({ type: 'Snapshot', items: ['a', 'b'] })
             expect(result[1].event).toEqual({ type: 'Item Added', item: 'c' })
         })
         
         it('should handle incoming timestamp as latest when greater than all events', () => {
             const recentEvents = [
-                { event: { type: 'Snapshot Generated' as const, items: [] }, timestamp: 10000 }
+                { event: { type: 'Snapshot' as const, items: [] }, timestamp: 10000 }
             ]
             
             const result = performCleanupWithConfig(recentEvents, 100000)
@@ -171,7 +171,7 @@ describe('dataSource reducers', () => {
             // Should consolidate to synthetic snapshot
             expect(result).toHaveLength(1)
             expect(result[0].timestamp).toBe(70000)
-            expect(result[0].event).toEqual({ type: 'Snapshot Generated', items: [] })
+            expect(result[0].event).toEqual({ type: 'Snapshot', items: [] })
         })
     })
     
@@ -194,7 +194,7 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['old'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['old'] },
                         recentEvents: [] as Array<{ event: TestSnapshot | TestUpdate; timestamp: number }>
                     }
                 }
@@ -204,7 +204,7 @@ describe('dataSource reducers', () => {
                 payload: {
                     streamKey: 'stream1',
                     timestamp: 10000,
-                    rawSnapshot: { type: 'Snapshot Generated' as const, items: ['new'] }
+                    rawSnapshot: { type: 'Snapshot' as const, items: ['new'] }
                 }
             }
             
@@ -212,17 +212,17 @@ describe('dataSource reducers', () => {
                 processSnapshot(draft, action as any)
             })
             
-            expect(mockSerializer.deserializeSnapshot).toHaveBeenCalledWith({ type: 'Snapshot Generated', items: ['new'] })
+            expect(mockSerializer.deserializeSnapshot).toHaveBeenCalledWith({ type: 'Snapshot', items: ['new'] })
             expect(newState.subscribedStreams['stream1'].materializedView.items).toEqual(['new'])
             expect(newState.subscribedStreams['stream1'].recentEvents).toHaveLength(1)
-            expect(newState.subscribedStreams['stream1'].recentEvents[0].event).toEqual({ type: 'Snapshot Generated', items: ['new'] })
+            expect(newState.subscribedStreams['stream1'].recentEvents[0].event).toEqual({ type: 'Snapshot', items: ['new'] })
         })
         
         it('should handle events that happened after snapshot', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a'] },
                         recentEvents: [
                             { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 20000 }
                         ]
@@ -234,7 +234,7 @@ describe('dataSource reducers', () => {
                 payload: {
                     streamKey: 'stream1',
                     timestamp: 15000,  // Snapshot comes BEFORE existing event
-                    rawSnapshot: { type: 'Snapshot Generated' as const, items: ['x'] }
+                    rawSnapshot: { type: 'Snapshot' as const, items: ['x'] }
                 }
             }
             
@@ -260,7 +260,7 @@ describe('dataSource reducers', () => {
                 payload: {
                     streamKey: 'nonexistent',
                     timestamp: 10000,
-                    rawSnapshot: { type: 'Snapshot Generated' as const, items: ['a'] }
+                    rawSnapshot: { type: 'Snapshot' as const, items: ['a'] }
                 }
             }
             
@@ -277,7 +277,7 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a'] },
                         recentEvents: [] as Array<{ event: TestSnapshot | TestUpdate; timestamp: number }>
                     }
                 }
@@ -326,7 +326,7 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a'] },
                         recentEvents: [
                             { event: { type: 'Item Added' as const, item: 'a' }, timestamp: 10000 }
                         ]
@@ -356,9 +356,9 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a', 'c'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a', 'c'] },
                         recentEvents: [
-                            { event: { type: 'Snapshot Generated' as const, items: ['a'] }, timestamp: 10000 },
+                            { event: { type: 'Snapshot' as const, items: ['a'] }, timestamp: 10000 },
                             { event: { type: 'Item Added' as const, item: 'c' }, timestamp: 30000 }
                         ]
                     }
@@ -413,7 +413,7 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a'] },
                         recentEvents: [] as Array<{ event: TestSnapshot | TestUpdate; timestamp: number }>
                     }
                 }
@@ -442,7 +442,7 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a', 'c'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a', 'c'] },
                         recentEvents: [
                             { event: { type: 'Item Added' as const, item: 'a' }, timestamp: 20000 },
                             { event: { type: 'Item Added' as const, item: 'c' }, timestamp: 40000 }
@@ -471,9 +471,9 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a', 'b'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a', 'b'] },
                         recentEvents: [
-                            { event: { type: 'Snapshot Generated' as const, items: [] }, timestamp: 10000 },
+                            { event: { type: 'Snapshot' as const, items: [] }, timestamp: 10000 },
                             { event: { type: 'Item Added' as const, item: 'a' }, timestamp: 20000 },
                             { event: { type: 'Item Added' as const, item: 'b' }, timestamp: 30000 }
                         ]
@@ -506,9 +506,9 @@ describe('dataSource reducers', () => {
             const initialPublicData = {
                 subscribedStreams: {
                     'stream1': {
-                        materializedView: { type: 'Snapshot Generated' as const, items: ['a', 'b', 'c'] },
+                        materializedView: { type: 'Snapshot' as const, items: ['a', 'b', 'c'] },
                         recentEvents: [
-                            { event: { type: 'Snapshot Generated' as const, items: ['a', 'b', 'c'] }, timestamp: 50000 }
+                            { event: { type: 'Snapshot' as const, items: ['a', 'b', 'c'] }, timestamp: 50000 }
                         ]
                     }
                 }

--- a/lambda/assets/contentHeaders/index.test.ts
+++ b/lambda/assets/contentHeaders/index.test.ts
@@ -154,7 +154,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             const snapshot = await contentHeadersDataSource.snapshotContentGenerator?.('global')
 
             expect(snapshot).toEqual({
-                type: 'Snapshot Generated',
+                type: 'Snapshot',
                 assets: []
             })
         })
@@ -192,7 +192,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
 
             // First, verify the overall structure
             expect(snapshot).toEqual({
-                type: 'Snapshot Generated',
+                type: 'Snapshot',
                 assets: [
                     {
                         assetId: 'ASSET#canon1',
@@ -245,7 +245,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             const snapshot = await contentHeadersDataSource.snapshotContentGenerator?.('global')
 
             expect(snapshot).toEqual({
-                type: 'Snapshot Generated',
+                type: 'Snapshot',
                 assets: []
             })
         })

--- a/lambda/assets/contentHeaders/index.ts
+++ b/lambda/assets/contentHeaders/index.ts
@@ -122,14 +122,14 @@ const generateContentHeadersSnapshot = async (): Promise<ContentHeadersSnapshot>
         ).then(results => results.filter(excludeUndefined))
         
         return {
-            type: 'Snapshot Generated',
+            type: 'Snapshot',
             assets: contentHeadersAssets
         }
     } catch (error) {
         console.error('Error generating content headers snapshot:', error)
         // Return empty snapshot on error
         return {
-            type: 'Snapshot Generated',
+            type: 'Snapshot',
             assets: []
         }
     }

--- a/packages/mtw-interfaces/ts/asset.test.ts
+++ b/packages/mtw-interfaces/ts/asset.test.ts
@@ -26,45 +26,6 @@ describe('AssetClientMessage typeguard', () => {
         })).toBe(false)
     })
 
-    describe('Player', () => {
-
-        it('should reject when no PlayerName', () => {
-            expect(isAssetClientMessage({
-                messageType: 'Player',
-                CodeOfConductConsent: true,
-                Assets: [],
-                Characters: [],
-                Settings: { onboardCompleteTags: [] },
-                SessionId: 'session123'
-            })).toBe(false)
-        })
-
-        it('should reject when wrong type PlayerName', () => {
-            expect(isAssetClientMessage({
-                messageType: 'Player',
-                PlayerName: 1234,
-                CodeOfConductConsent: true,
-                Assets: [],
-                Characters: [],
-                Settings: { onboardCompleteTags: [] },
-                SessionId: 'session123'
-            })).toBe(false)
-        })
-
-        it('should accept correct entry', () => {
-            expect(isAssetClientMessage({
-                messageType: 'Player',
-                PlayerName: 'TestPlayer',
-                CodeOfConductConsent: true,
-                Assets: [],
-                Characters: [],
-                Settings: { onboardCompleteTags: [] },
-                SessionId: 'session123'
-            })).toBe(true)
-        })
-
-    })
-
     describe('Library', () => {
 
         it('should reject when no Assets field', () => {

--- a/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/baseClasses.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/baseClasses.ts
@@ -11,7 +11,7 @@ import { Zone, isZone } from '@tonylb/mtw-interfaces/ts/baseClasses'
 export type ContentHeadersEventUpdate = ContentHeadersSnapshot | ContentHeadersUpdate | ZoneUpdatedEvent
 
 export type ContentHeadersSnapshot = {
-    type: 'Snapshot Generated'
+    type: 'Snapshot'
     assets: Array<{
         assetId: AssetUUID
         zone: Zone
@@ -32,7 +32,7 @@ export const isContentHeadersSnapshot = (event: any): event is ContentHeadersSna
         event &&
         typeof event === 'object' &&
         'type' in event &&
-        event.type === 'Snapshot Generated' &&
+        event.type === 'Snapshot' &&
         'assets' in event &&
         Array.isArray(event.assets)
     )
@@ -87,7 +87,7 @@ export class ContentHeadersAggregator {
      */
     createEmpty(): ContentHeadersSnapshot {
         return {
-            type: 'Snapshot Generated',
+            type: 'Snapshot',
             assets: []
         }
     }
@@ -119,7 +119,7 @@ export class ContentHeadersAggregator {
                 return {
                     success: true,
                     snapshot: {
-                        type: 'Snapshot Generated',
+                        type: 'Snapshot',
                         assets: [
                             ...baselineAssets,
                             {
@@ -148,7 +148,7 @@ export class ContentHeadersAggregator {
                 return {
                     success: true,
                     snapshot: {
-                        type: 'Snapshot Generated',
+                        type: 'Snapshot',
                         assets: [
                             ...baselineAssets,
                             {
@@ -160,7 +160,7 @@ export class ContentHeadersAggregator {
                     }
                 }
             } else if (isContentHeadersSnapshot(update)) {
-                // Handle Snapshot Generated event - replace entire snapshot
+                // Handle Snapshot event - replace entire snapshot
                 return {
                     success: true,
                     snapshot: update

--- a/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/index.test.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/index.test.ts
@@ -21,7 +21,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                 const snapshot = aggregator.createEmpty()
                 
                 expect(snapshot).toEqual({
-                    type: 'Snapshot Generated',
+                    type: 'Snapshot',
                     assets: []
                 })
             })
@@ -64,7 +64,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                     `))
                     
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -106,7 +106,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                     `))
                     
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -151,7 +151,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                     `))
                     
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -226,7 +226,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                     `))
                     
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -273,7 +273,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
 
                 it('should preserve other assets when updating zone', () => {
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [
                             {
                                 assetId: 'ASSET#test1' as const,
@@ -315,10 +315,10 @@ describe('ContentHeaders EventBridge Contracts', () => {
                 })
             })
 
-            describe('Snapshot Generated events', () => {
+            describe('Snapshot events', () => {
                 it('should replace entire snapshot', () => {
                     const oldSnapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#old' as const,
                             zone: 'Canon' as const,
@@ -327,7 +327,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                     }
 
                     const newSnapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#new' as const,
                             zone: 'Library' as const,
@@ -348,7 +348,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                 it('should return error when merge fails', () => {
                     // Create a snapshot with a StandardForm
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -389,7 +389,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
 
                 it('should return unchanged snapshot on error', () => {
                     const snapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -423,7 +423,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
             describe('Immutability', () => {
                 it('should not mutate the original snapshot on Headers Updated', () => {
                     const originalSnapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -444,7 +444,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
 
                 it('should not mutate the original snapshot on Zone Updated', () => {
                     const originalSnapshot = {
-                        type: 'Snapshot Generated' as const,
+                        type: 'Snapshot' as const,
                         assets: [{
                             assetId: 'ASSET#test' as const,
                             zone: 'Canon' as const,
@@ -536,7 +536,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
         describe('serializeSnapshot', () => {
             it('should serialize snapshot to external format', () => {
                 const snapshot = {
-                    type: 'Snapshot Generated' as const,
+                    type: 'Snapshot' as const,
                     assets: [
                         {
                             assetId: 'ASSET#test1' as const,
@@ -554,7 +554,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                 const result = serializer.serializeSnapshot(snapshot)
 
                 expect(result).toEqual({
-                    type: 'Snapshot Generated',
+                    type: 'Snapshot',
                     assets: [
                         {
                             assetId: 'ASSET#test1',
@@ -574,7 +574,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
         describe('deserializeSnapshot', () => {
             it('should deserialize snapshot from external format', () => {
                 const externalSnapshot: ContentHeadersSnapshotExternal = {
-                    type: 'Snapshot Generated',
+                    type: 'Snapshot',
                     assets: [
                         {
                             assetId: 'ASSET#test1',
@@ -592,7 +592,7 @@ describe('ContentHeaders EventBridge Contracts', () => {
                 const result = serializer.deserializeSnapshot(externalSnapshot)
 
                 expect(result).not.toBeNull()
-                expect(result?.type).toBe('Snapshot Generated')
+                expect(result?.type).toBe('Snapshot')
                 expect(result?.assets).toHaveLength(2)
                 expect(result?.assets[0].assetId).toBe('ASSET#test1')
                 expect(result?.assets[0].zone).toBe('Canon')

--- a/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/index.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/assets/contentHeaders/index.ts
@@ -41,7 +41,7 @@ export {
 // External event format (EventBridge) - using WML strings
 // External snapshot uses an array for efficient JSON transmission
 export type ContentHeadersSnapshotExternal = {
-    type: 'Snapshot Generated'
+    type: 'Snapshot'
     assets: Array<{
         assetId: AssetUUID
         zone: Zone
@@ -123,7 +123,7 @@ export class ContentHeadersEventSerializer implements DataSourceEventSerializer<
         }))
         
         return {
-            type: 'Snapshot Generated',
+            type: 'Snapshot',
             assets: externalAssets
         }
     }
@@ -138,7 +138,7 @@ export class ContentHeadersEventSerializer implements DataSourceEventSerializer<
             }))
             
             return {
-                type: 'Snapshot Generated',
+                type: 'Snapshot',
                 assets: internalAssets
             }
         } catch (error) {
@@ -154,7 +154,7 @@ export const isContentHeadersExternal = (event: any): event is ContentHeadersExt
         return false
     }
     switch((event as any).type) {
-        case 'Snapshot Generated':
+        case 'Snapshot':
             return Boolean(
                 event.assets &&
                 Array.isArray(event.assets)

--- a/packages/mtw-interfaces/ts/eventBridge/assets/index.test.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/assets/index.test.ts
@@ -153,7 +153,8 @@ describe('AssetsEventSerializer', () => {
 
         it('should serialize Asset Removed event (pass-through)', () => {
             const assetEvent: AssetLevelEventUpdate = {
-                type: 'Asset Removed'
+                type: 'Asset Removed',
+                zone: 'Canon'
             }
 
             const externalEvent = serializer.serialize({
@@ -163,6 +164,9 @@ describe('AssetsEventSerializer', () => {
             })
 
             expect(externalEvent.type).toBe('Asset Removed')
+            if (externalEvent.type === 'Asset Removed') {
+                expect(externalEvent.zone).toBe('Canon')
+            }
         })
 
         it('should serialize Canon Updated event (pass-through)', () => {

--- a/packages/mtw-interfaces/ts/eventBridge/assets/players/index.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/assets/players/index.ts
@@ -22,13 +22,6 @@ export type PlayerSnapshot = {
     settings: AssetClientPlayerSettings
 }
 
-export type PlayerSnapshotGenerated = {
-    type: 'Snapshot Generated'
-    assets: LibraryAsset[]
-    characters: LibraryCharacter[]
-    settings: AssetClientPlayerSettings
-}
-
 export type PlayerSettingsUpdated = {
     type: 'Player Settings Updated'
     settings: AssetClientPlayerSettings
@@ -67,10 +60,9 @@ export type PlayerEventUpdate =
 // Internal and external formats are currently identical pass-throughs.
 //
 
-export type PlayerSnapshotExternal = PlayerSnapshot | PlayerSnapshotGenerated
+export type PlayerSnapshotExternal = PlayerSnapshot
 export type PlayerExternal =
     | PlayerSnapshot
-    | PlayerSnapshotGenerated
     | PlayerSettingsUpdated
     | PlayerAssetAssigned
     | PlayerAssetRemoved
@@ -115,17 +107,6 @@ const isPlayerSettings = (value: any): value is AssetClientPlayerSettings => (
     value.onboardCompleteTags.every((entry: any) => typeof entry === 'string') &&
     (value.guestName === undefined || typeof value.guestName === 'string') &&
     (value.guestId === undefined || typeof value.guestId === 'string')
-)
-
-const isPlayerSnapshotGenerated = (value: any): value is PlayerSnapshotGenerated => (
-    value &&
-    typeof value === 'object' &&
-    value.type === 'Snapshot Generated' &&
-    Array.isArray(value.assets) &&
-    value.assets.every(isLibraryAsset) &&
-    Array.isArray(value.characters) &&
-    value.characters.every(isLibraryCharacter) &&
-    isPlayerSettings(value.settings)
 )
 
 export const isPlayerSnapshot = (value: any): value is PlayerSnapshot => (
@@ -176,7 +157,6 @@ export const isPlayerCharacterRemoved = (value: any): value is PlayerCharacterRe
 
 export const isPlayerExternal = (value: any): value is PlayerExternal => (
     isPlayerSnapshot(value) ||
-    isPlayerSnapshotGenerated(value) ||
     isPlayerSettingsUpdated(value) ||
     isPlayerAssetAssigned(value) ||
     isPlayerAssetRemoved(value) ||
@@ -247,7 +227,7 @@ export class PlayerEventSerializer implements DataSourceEventSerializer<
         externalUpdate: PlayerExternal
     }): PlayerEventUpdate | null {
         const { externalUpdate } = params
-        if (isPlayerSnapshot(externalUpdate) || isPlayerSnapshotGenerated(externalUpdate)) {
+        if (isPlayerSnapshot(externalUpdate)) {
             return {
                 type: 'Snapshot',
                 assets: externalUpdate.assets.map((asset) => ({ ...asset })),
@@ -302,12 +282,10 @@ export class PlayerEventSerializer implements DataSourceEventSerializer<
     }
 
     deserializeSnapshot(externalSnapshot: PlayerSnapshotExternal): PlayerSnapshot | null {
-        // Accept both 'Snapshot' and 'Snapshot Generated' types
-        if (!isPlayerSnapshot(externalSnapshot) && !isPlayerSnapshotGenerated(externalSnapshot)) {
+        if (!isPlayerSnapshot(externalSnapshot)) {
             console.error('Invalid player snapshot external payload', externalSnapshot)
             return null
         }
-        // Convert to internal 'Snapshot' format (normalize 'Snapshot Generated' to 'Snapshot')
         return {
             type: 'Snapshot',
             assets: externalSnapshot.assets.map((asset) => ({ ...asset })),

--- a/packages/mtw-lambda-patterns/ts/dataSource/index.ts
+++ b/packages/mtw-lambda-patterns/ts/dataSource/index.ts
@@ -188,7 +188,7 @@ export class DataSource<
             
             const externalSnapshot: SnapshotType<ExternalSnapshotPayload> = {
                 ...externalPayload,
-                type: 'Snapshot Generated',
+                type: 'Snapshot',
                 createdAt: internalSnapshot.createdAt,
                 expiresAt: internalSnapshot.expiresAt
             }
@@ -233,7 +233,7 @@ export class DataSource<
                 
                 const externalSnapshot: SnapshotType<ExternalSnapshotPayload> = {
                     ...externalPayload,
-                    type: 'Snapshot Generated',
+                    type: 'Snapshot',
                     createdAt: internalSnapshot.createdAt,
                     expiresAt: internalSnapshot.expiresAt
                 }
@@ -528,7 +528,7 @@ export class DataSource<
         // Return the Core External format directly (no deserialization needed)
         return result?.snapshot ? {
             ...result!.snapshot,
-            type: 'Snapshot Generated'
+            type: 'Snapshot'
         } : undefined
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames the snapshot event type from `Snapshot Generated` to `Snapshot` across client, interfaces, lambda, and core patterns; removes legacy player `Snapshot Generated` support; updates serializers, aggregators, routing, and tests.
> 
> - **Event Schema**:
>   - Rename `type` from `Snapshot Generated` to `Snapshot` across all modules (core patterns, serializers, aggregators, type guards).
> - **Client (charcoal-client)**:
>   - Route incoming updates as snapshots when `update.type === 'Snapshot'`.
>   - Update reducers/tests and mock aggregators to use `type: 'Snapshot'`.
> - **Lambda (contentHeaders)**:
>   - Snapshot generator now returns `type: 'Snapshot'`.
>   - Tests updated accordingly.
> - **Interfaces (mtw-interfaces)**:
>   - ContentHeaders: update types, guards, serializer (serialize/deserializeSnapshot) to `Snapshot`.
>   - Players: remove `Snapshot Generated` variant/types/guards; normalize snapshots to `Snapshot`.
>   - Assets tests: add zone assertion for `Asset Removed` event.
> - **Core (mtw-lambda-patterns)**:
>   - DataSource snapshot I/O normalizes stored/returned snapshots to `type: 'Snapshot'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d53a0b4255900d353e1390405e69881a305fa815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->