### PR TITLE
ISS6307: Added explicit Parent tag to WML

### DIFF
--- a/packages/mtw-base/ts/schema/components.ts
+++ b/packages/mtw-base/ts/schema/components.ts
@@ -5,6 +5,10 @@ import { ComponentUUID, isSchemaAssetUUID } from ".";
 
 export type SchemaShortNameTag = SchemaLiteralTag<'ShortName'>
 
+export type SchemaParentTag = {
+    tag: 'Parent';
+}
+
 export type SchemaExitTag = {
     tag: 'Exit';
     to: string;
@@ -57,6 +61,13 @@ export type SchemaMomentTag = {
 
 const { typeGuard } = literalTagFactory<'ShortName'>('ShortName')
 export const isSchemaShortName = typeGuard
+
+export const isSchemaParent = (schema: any): schema is SchemaParentTag => (
+    checkTypes({
+        required: { tag: CheckTypes.STRING },
+        values: { tag: 'Parent' }
+    })(schema)
+)
 
 export const isSchemaExit = (schema: any): schema is SchemaExitTag => (
     checkTypes({

--- a/packages/mtw-base/ts/schema/index.ts
+++ b/packages/mtw-base/ts/schema/index.ts
@@ -1,7 +1,7 @@
 import { SchemaAssetTag, SchemaStoryTag } from "./asset"
 import { isSchemaGrant, SchemaGrantTag } from "./authorization"
 import { isSchemaPronouns, SchemaCharacterLegalContents, SchemaCharacterTag, SchemaPronounsTag } from "./character"
-import { isSchemaExit, isSchemaFeature, isSchemaKnowledge, isSchemaMap, isSchemaMessage, isSchemaMoment, isSchemaPosition, isSchemaRoom, isSchemaShortName, SchemaExitTag, SchemaFeatureTag, SchemaKnowledgeTag, SchemaMapTag, SchemaMessageTag, SchemaMomentTag, SchemaPositionTag, SchemaRoomTag, SchemaShortNameTag } from "./components"
+import { isSchemaExit, isSchemaFeature, isSchemaKnowledge, isSchemaMap, isSchemaMessage, isSchemaMoment, isSchemaPosition, isSchemaRoom, isSchemaShortName, isSchemaParent, SchemaExitTag, SchemaFeatureTag, SchemaKnowledgeTag, SchemaMapTag, SchemaMessageTag, SchemaMomentTag, SchemaPositionTag, SchemaRoomTag, SchemaShortNameTag, SchemaParentTag } from "./components"
 
 import { isSchemaEdit, isSchemaRemove, isSchemaReplace, isSchemaReplaceMatch, isSchemaReplacePayload, SchemaEditTag, SchemaReplaceTag } from "./edit"
 import { isSchemaDescription, isSchemaExample, isSchemaName, isSchemaSummary, SchemaDescriptionTag, SchemaExampleTag, SchemaNameTag, SchemaSummaryTag } from "./example"
@@ -61,7 +61,8 @@ export type SchemaTag = SchemaAssetTag |
     SchemaMessageTag |
     SchemaMomentTag |
     SchemaEditTag |
-    SchemaGrantTag
+    SchemaGrantTag |
+    SchemaParentTag
 
 export type SchemaWithContents = SchemaAssetTag |
     SchemaStoryTag |
@@ -149,7 +150,8 @@ export const isSchemaTag = (value: any): value is SchemaTag => {
         isSchemaMessage(value) ||
         isSchemaMoment(value) ||
         isSchemaEdit(value) ||
-        isSchemaGrant(value)
+        isSchemaGrant(value) ||
+        isSchemaParent(value)
 }
 
 export type SchemaToWMLTopLevelOptions = {

--- a/packages/mtw-base/ts/schema/tagType.ts
+++ b/packages/mtw-base/ts/schema/tagType.ts
@@ -32,7 +32,8 @@ export type SchemaTagType =
     'String' |
     'Message' |
     'Moment' |
-    'Grant'
+    'Grant' |
+    'Parent'
 
 export const isLegalSchemaTag = (value: any): value is SchemaTagType => (
     typeof value === 'string' && [
@@ -69,6 +70,7 @@ export const isLegalSchemaTag = (value: any): value is SchemaTagType => (
         'String',
         'Message',
         'Moment',
-        'Grant'
+        'Grant',
+        'Parent'
     ].includes(value)
 )

--- a/packages/mtw-wml/jest.config.js
+++ b/packages/mtw-wml/jest.config.js
@@ -1,10 +1,15 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 export default {
   globals: {
-      extensionsToTreatAsEsm: ['.ts', '.js'],
-      'ts-jest': {
-          useESM: true
-      }
+      extensionsToTreatAsEsm: ['.ts', '.js']
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true
+      },
+    ],
   },
   preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'node',

--- a/packages/mtw-wml/package.json
+++ b/packages/mtw-wml/package.json
@@ -14,11 +14,11 @@
     "@tonylb/mtw-base": "file:../mtw-base"
   },
   "devDependencies": {
-    "@types/jest": "^28.1.3",
+    "@types/jest": "^29.1.2",
     "@types/uuid": "^8.3.4",
-    "jest": "^28.1.1",
+    "jest": "^29.1.2",
     "madge": "^5.0.1",
-    "ts-jest": "^28.0.5",
+    "ts-jest": "^29.0.3",
     "typescript": "^4.7.4"
   }
 }

--- a/packages/mtw-wml/ts/schema/converters/components.test.ts
+++ b/packages/mtw-wml/ts/schema/converters/components.test.ts
@@ -1,0 +1,188 @@
+import parse from '../../simpleParser'
+import tokenizer from '../../parser/tokenizer'
+import SourceStream from '../../parser/tokenizer/sourceStream'
+
+import { schemaFromParse, schemaToWML } from '../index'
+import { deIndentWML } from '../utils'
+import { isSchemaParent } from '@tonylb/mtw-base/ts/schema/components'
+
+describe('Parent tag', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        jest.resetAllMocks()
+    })
+
+    describe('parsing', () => {
+        it('should parse Parent tag inside a Room with ComponentUUID', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)><Parent>ROOM#parent-room</Parent></Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+            expect(parentNode?.children[0].data).toEqual({ tag: 'String', value: 'ROOM#parent-room' })
+        })
+
+        it('should parse Parent tag inside a Feature with ComponentUUID', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Feature key=(feature1)><Parent>ROOM#parent-room</Parent></Feature>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const featureNode = schema[0].children.find(({ data }) => data.tag === 'Feature')
+            expect(featureNode).toBeDefined()
+            const parentNode = featureNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+        })
+
+        it('should parse Parent tag inside a Knowledge with ComponentUUID', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Knowledge key=(knowledge1)><Parent>FEATURE#parent-feature</Parent></Knowledge>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const knowledgeNode = schema[0].children.find(({ data }) => data.tag === 'Knowledge')
+            expect(knowledgeNode).toBeDefined()
+            const parentNode = knowledgeNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+        })
+
+        it('should parse Parent tag with AssetUUID', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)><Parent>ASSET#parent-asset</Parent></Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+        })
+    })
+
+    describe('validation', () => {
+        it('should reject Parent tag when not inside a ComponentUUID', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Parent>ROOM#parent-room</Parent>
+                </Asset>
+            `))))
+            expect(() => schemaFromParse(testParse)).toThrow('Parent tag can only be used inside a ComponentUUID (Room, Feature, etc.)')
+        })
+
+        it('should reject Parent tag with invalid ComponentUUID content', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Parent>not-a-valid-uuid</Parent>
+                    </Room>
+                </Asset>
+            `))))
+            expect(() => schemaFromParse(testParse)).toThrow('Parent tag content must be a ComponentUUID, got: not-a-valid-uuid')
+        })
+
+        it('should reject Parent tag with empty content', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Parent></Parent>
+                    </Room>
+                </Asset>
+            `))))
+            expect(() => schemaFromParse(testParse)).toThrow('Parent tag content must be a ComponentUUID')
+        })
+
+        it('should reject Parent tag with properties', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Parent key=(invalid)>ROOM#parent-room</Parent>
+                    </Room>
+                </Asset>
+            `))))
+            expect(() => schemaFromParse(testParse)).toThrow("Property 'key' is not allowed in 'Parent' items.")
+        })
+    })
+
+    describe('serialization', () => {
+        it('should round-trip Parent tag correctly', () => {
+            const testWML = deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)><Parent>ROOM#parent-room</Parent></Room>
+                </Asset>
+            `)
+            expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(testWML)
+        })
+
+        it('should round-trip Parent tag with AssetUUID', () => {
+            const testWML = deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Feature key=(feature1)><Parent>ASSET#parent-asset</Parent></Feature>
+                </Asset>
+            `)
+            expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(testWML)
+        })
+
+        it('should round-trip Parent tag with different component types', () => {
+            const testWML = deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)><Parent>FEATURE#parent-feature</Parent></Room>
+                    <Feature key=(feature1)><Parent>ROOM#parent-room</Parent></Feature>
+                    <Knowledge key=(knowledge1)><Parent>ROOM#parent-room</Parent></Knowledge>
+                </Asset>
+            `)
+            expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(testWML)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('should handle Parent tag with multiple string children that combine to ComponentUUID', () => {
+            // This tests that if a ComponentUUID is split across multiple string nodes,
+            // they are properly combined and validated
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Parent>ROOM#parent</Parent>
+                    </Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            // The finalize function should have validated and normalized the content
+            expect(parentNode?.children.length).toBeGreaterThan(0)
+        })
+
+        it('should allow Parent tag alongside other content in a Room', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Name>Test Room</Name>
+                        <Parent>ROOM#parent-room</Parent>
+                        <Description>Room description</Description>
+                    </Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            const nameNode = roomNode?.children.find(({ data }) => data.tag === 'Name')
+            expect(nameNode).toBeDefined()
+        })
+    })
+})
+

--- a/packages/mtw-wml/ts/schema/converters/components.ts
+++ b/packages/mtw-wml/ts/schema/converters/components.ts
@@ -4,11 +4,11 @@ import { ConverterMapEntry, PrintMapEntry, PrintMapEntryArguments } from "./base
 import { tagRender } from "./tagRender"
 import { validateProperties } from "./utils"
 import { GenericTree, GenericTreeNodeFiltered } from "@tonylb/mtw-base/ts/genericTree"
-import { isSchemaExit, isSchemaFeature, isSchemaKnowledge, isSchemaMap, isSchemaPosition, isSchemaRoom, isSchemaShortName, SchemaExitTag, SchemaFeatureTag, SchemaKnowledgeTag, SchemaMapTag, SchemaPositionTag, SchemaRoomTag, SchemaShortNameTag } from "@tonylb/mtw-base/ts/schema/components"
-import { isSchemaString } from "@tonylb/mtw-base/ts/schema/renderTree"
-import { isSchemaMapContents, SchemaTag } from "@tonylb/mtw-base/ts/schema"
+import { isSchemaExit, isSchemaFeature, isSchemaKnowledge, isSchemaMap, isSchemaPosition, isSchemaRoom, isSchemaShortName, isSchemaParent, SchemaExitTag, SchemaFeatureTag, SchemaKnowledgeTag, SchemaMapTag, SchemaPositionTag, SchemaRoomTag, SchemaShortNameTag, SchemaParentTag } from "@tonylb/mtw-base/ts/schema/components"
+import { isSchemaString, SchemaStringTag } from "@tonylb/mtw-base/ts/schema/renderTree"
+import { isSchemaMapContents, SchemaTag, isSchemaComponent, isSchemaComponentUUID } from "@tonylb/mtw-base/ts/schema"
 import { isSchemaName } from "@tonylb/mtw-base/ts/schema/example"
-import { PrintMode } from "@tonylb/mtw-base/ts/schema/printMap"
+import { PrintMode, PrintMapResult } from "@tonylb/mtw-base/ts/schema/printMap"
 import { literalTagFactory } from "@tonylb/mtw-base/ts/schema/literalTagFactory"
 import { enforceTypedKey, stripTypedKey } from "@tonylb/mtw-utilities/ts/types"
 
@@ -53,6 +53,26 @@ const componentTemplates = {
 
 const { converter: shortNameConverter, printMap: shortNamePrintMap } = literalTagFactory('ShortName')
 
+// Parent tag converter - similar to Literal but constrained to ComponentUUID content
+// and can only be placed inside ComponentUUID tags
+const parentTagRenderLiteral = ({ tag: { data: tag, children }, ...args }: PrintMapEntryArguments): PrintMapResult[] => {
+    if (!isSchemaParent(tag)) {
+        return [{ printMode: PrintMode.naive, output: '' }]
+    }
+    const textValue = children.map(({ data }) => (data)).filter(isSchemaString).map(({ value }) => (value)).join('') as string
+    const naive = `<${tag.tag}>${textValue}</${tag.tag}>`
+    if (naive.length + Math.min(10, args.options.indent * 4) > 80) {
+        return [
+            { printMode: PrintMode.nested, output: `<${tag.tag}>` },
+            { printMode: PrintMode.nested, output: `    ${textValue}` },
+            { printMode: PrintMode.nested, output: `</${tag.tag}>` }
+        ]
+    }
+    else {
+        return [{ printMode: PrintMode.naive, output: `<${tag.tag}>${textValue}</${tag.tag}>` }]
+    }
+}
+
 export const componentConverters: Record<string, ConverterMapEntry> = {
     Exit: {
         initialize: ({ parseOpen, contextStack }): SchemaExitTag => {
@@ -75,6 +95,46 @@ export const componentConverters: Record<string, ConverterMapEntry> = {
         }
     },
     ShortName: shortNameConverter,
+    Parent: {
+        initialize: ({ parseOpen, contextStack }): SchemaParentTag => {
+            // Validate that Parent tag is inside a ComponentUUID
+            const hasComponentContext = contextStack.some(({ data }) => isSchemaComponent(data))
+            if (!hasComponentContext) {
+                throw new Error(`Parent tag can only be used inside a ComponentUUID (Room, Feature, etc.)`)
+            }
+            if (!(parseOpen && typeof parseOpen === 'object' && 'properties' in parseOpen && Array.isArray(parseOpen.properties))) {
+                throw new Error('Invalid parseOpen object')
+            }
+            const unmatchedKey = parseOpen.properties[0]
+            if (unmatchedKey) {
+                throw new Error(`Property '${unmatchedKey.key}' is not allowed in 'Parent' items.`)
+            }
+            return { tag: 'Parent' }
+        },
+        typeCheckContents: (item: SchemaTag): boolean => {
+            // Parent can only contain String tags (ComponentUUID may be split across multiple strings)
+            // The combined result will be validated in finalize
+            return isSchemaString(item)
+        },
+        finalize: (initialTag: SchemaTag, children: GenericTree<SchemaTag>): GenericTreeNodeFiltered<SchemaParentTag, SchemaStringTag> => {
+            if (!isSchemaParent(initialTag)) {
+                throw new Error('Type mismatch on schema finalize')
+            }
+            // Validate that the combined string content is a ComponentUUID
+            const textValue = children
+                .map(({ data }) => data)
+                .filter(isSchemaString)
+                .map(({ value }) => value)
+                .join('')
+            if (!isSchemaComponentUUID(textValue)) {
+                throw new Error(`Parent tag content must be a ComponentUUID, got: ${textValue}`)
+            }
+            return {
+                data: { tag: 'Parent' },
+                children: children.map(({ data }) => data).filter(isSchemaString).map(({ value }) => ({ data: { tag: 'String' as const, value }, children: [] }))
+            }
+        }
+    },
     Room: {
         initialize: ({ parseOpen }): SchemaRoomTag => {
             const { uuid, ...rest } = validateProperties(componentTemplates.Room)(parseOpen)   
@@ -172,6 +232,7 @@ export const componentPrintMap: Record<string, PrintMapEntry> = {
         })
     },
     ShortName: shortNamePrintMap,
+    Parent: parentTagRenderLiteral,
     Room: ({ tag: { data: tag, children }, ...args }: PrintMapEntryArguments) => {
         //
         // Reassemble the contents out of name and description fields


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a `Parent` tag to the schema and WML converter with validation and printing, plus comprehensive tests and Jest config/dependency updates.
> 
> - **Schema (`@tonylb/mtw-base`)**:
>   - Add `SchemaParentTag` and `isSchemaParent` in `ts/schema/components.ts`.
>   - Include `Parent` in `SchemaTag` unions and `isSchemaTag` checks in `ts/schema/index.ts`.
>   - Add `Parent` to legal tag types in `ts/schema/tagType.ts`.
> - **WML Converters (`@tonylb/mtw-wml`)**:
>   - Implement `Parent` tag converter in `ts/schema/converters/components.ts` with:
>     - Context validation (must be inside a component), string-only contents, and `ComponentUUID` content check on finalize.
>     - Print map for inline/nested rendering.
> - **Tests**:
>   - Add `Parent` tag parsing/validation/serialization tests in `ts/schema/converters/components.test.ts`.
> - **Tooling**:
>   - Update `jest.config.js` to use `transform` with `ts-jest` ESM.
>   - Bump dev deps: `jest`, `ts-jest`, `@types/jest` in `packages/mtw-wml/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22457610df86693f772ee7e5c06c07c76d209caf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->