### PR TITLE
ISS6439: Allowed for empty Parent tags and updated snapshots to new J…

### DIFF
--- a/packages/mtw-wml/ts/__snapshots__/dungeon.test.ts.snap
+++ b/packages/mtw-wml/ts/__snapshots__/dungeon.test.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`large WML test should parse properly 1`] = `
-Array [
-  Object {
-    "properties": Array [
-      Object {
+[
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "Dungeon",
@@ -13,9 +13,9 @@ Array [
     "tag": "Asset",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "VORTEX",
@@ -24,9 +24,9 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "cave",
@@ -35,17 +35,17 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "cave",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "example1",
@@ -54,52 +54,52 @@ Array [
     "tag": "Example",
     "type": 0,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Description",
     "type": 0,
   },
-  Object {
+  {
     "text": "Natural rock formations rise in a jagged cliff-face. An asymmetric opening leads into a dimly lit cave. ",
     "type": 3,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "br",
     "type": 1,
   },
-  Object {
+  {
     "text": " (You could also go literally anywhere else in the world, if any of it had been created. But it hasn't)",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Description",
     "type": 2,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Name",
     "type": 0,
   },
-  Object {
+  {
     "text": "Cave entrance",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Name",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Example",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "dungeonMap",
@@ -108,9 +108,9 @@ Array [
     "tag": "Map",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "dungeonImage",
@@ -119,9 +119,9 @@ Array [
     "tag": "Image",
     "type": 1,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "VORTEX",
@@ -130,14 +130,14 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "x",
         "type": 1,
         "value": "0",
       },
-      Object {
+      {
         "key": "y",
         "type": 1,
         "value": "250",
@@ -146,13 +146,13 @@ Array [
     "tag": "Position",
     "type": 1,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "cave",
@@ -161,14 +161,14 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "x",
         "type": 1,
         "value": "0",
       },
-      Object {
+      {
         "key": "y",
         "type": 1,
         "value": "150",
@@ -177,9 +177,9 @@ Array [
     "tag": "Position",
     "type": 1,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "curvingPassage",
@@ -188,17 +188,17 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "passage",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "VORTEX",
@@ -207,21 +207,21 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "out",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "curvingPassage",
@@ -230,14 +230,14 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "x",
         "type": 1,
         "value": "-150",
       },
-      Object {
+      {
         "key": "y",
         "type": 1,
         "value": "100",
@@ -246,9 +246,9 @@ Array [
     "tag": "Position",
     "type": 1,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "cave",
@@ -257,17 +257,17 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "cave",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "chamber",
@@ -276,21 +276,21 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "chamber",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "chamber",
@@ -299,14 +299,14 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "x",
         "type": 1,
         "value": "-150",
       },
-      Object {
+      {
         "key": "y",
         "type": 1,
         "value": "0",
@@ -315,9 +315,9 @@ Array [
     "tag": "Position",
     "type": 1,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "curvingPassage",
@@ -326,25 +326,25 @@ Array [
     "tag": "Exit",
     "type": 0,
   },
-  Object {
+  {
     "text": "passage",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Exit",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Map",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "cave",
@@ -353,9 +353,9 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "example2",
@@ -364,39 +364,39 @@ Array [
     "tag": "Example",
     "type": 0,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Name",
     "type": 0,
   },
-  Object {
+  {
     "text": "Shallow cave",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Name",
     "type": 2,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Description",
     "type": 0,
   },
-  Object {
+  {
     "text": "Light streams in from the entrance. On one side of the cave is an old firepit and comfortably tamped-down earth floor. At the opposite end, a jumbled pile of jagged rocks against the wall make a far less hospitable space.",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Description",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Example",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "example3",
@@ -405,43 +405,43 @@ Array [
     "tag": "Example",
     "type": 0,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Name",
     "type": 0,
   },
-  Object {
+  {
     "text": "Shallow cave",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Name",
     "type": 2,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Description",
     "type": 0,
   },
-  Object {
+  {
     "text": "Light streams in from the entrance. On one side of the cave is an old firepit and comfortably tamped-down earth floor. At the opposite end, rocks have been cleared revealing a passage further underground.",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Description",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Example",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "curvingPassage",
@@ -450,9 +450,9 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "example4",
@@ -461,43 +461,43 @@ Array [
     "tag": "Example",
     "type": 0,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Name",
     "type": 0,
   },
-  Object {
+  {
     "text": "Curving Passage",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Name",
     "type": 2,
   },
-  Object {
-    "properties": Array [],
+  {
+    "properties": [],
     "tag": "Description",
     "type": 0,
   },
-  Object {
+  {
     "text": "Walls smoothly cut from the bedrock curve in a long arc, lit every few yards by a small sconce mounted above eye-level.",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Description",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Example",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "chamber",
@@ -506,9 +506,9 @@ Array [
     "tag": "Room",
     "type": 0,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "orc",
@@ -517,13 +517,13 @@ Array [
     "tag": "Feature",
     "type": 0,
   },
-  Object {
+  {
     "tag": "Feature",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "key",
         "type": 0,
         "value": "pie",
@@ -532,13 +532,13 @@ Array [
     "tag": "Feature",
     "type": 0,
   },
-  Object {
+  {
     "tag": "Feature",
     "type": 2,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "uuid",
         "type": 0,
         "value": "example5",
@@ -547,13 +547,13 @@ Array [
     "tag": "Example",
     "type": 0,
   },
-  Object {
+  {
     "text": "A ten-by-ten squared off cut stone room. Across from the passage leading in is a table with a ",
     "type": 3,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "pie",
@@ -562,21 +562,21 @@ Array [
     "tag": "Link",
     "type": 0,
   },
-  Object {
+  {
     "text": "pie",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Link",
     "type": 2,
   },
-  Object {
+  {
     "text": ". Standing before the table is an angry ",
     "type": 3,
   },
-  Object {
-    "properties": Array [
-      Object {
+  {
+    "properties": [
+      {
         "key": "to",
         "type": 0,
         "value": "orc",
@@ -585,27 +585,27 @@ Array [
     "tag": "Link",
     "type": 0,
   },
-  Object {
+  {
     "text": "orc",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Link",
     "type": 2,
   },
-  Object {
+  {
     "text": ".",
     "type": 3,
   },
-  Object {
+  {
     "tag": "Example",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Room",
     "type": 2,
   },
-  Object {
+  {
     "tag": "Asset",
     "type": 2,
   },
@@ -613,32 +613,32 @@ Array [
 `;
 
 exports[`large WML test should standardize properly 1`] = `
-Array [
-  Object {
+[
+  {
     "context": undefined,
     "key": "dungeonImage",
     "tag": "Image",
     "universalKey": undefined,
   },
-  Object {
+  {
     "context": undefined,
-    "examples": Array [
+    "examples": [
       "EXAMPLE#example2",
       "EXAMPLE#example3",
     ],
-    "exits": Array [
-      Object {
+    "exits": [
+      {
         "description": "passage",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "curvingPassage",
           "tag": "Room",
           "universalKey": undefined,
         },
       },
-      Object {
+      {
         "description": "out",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "VORTEX",
           "tag": "Room",
@@ -651,55 +651,55 @@ Array [
     "tag": "Room",
     "universalKey": undefined,
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "cave",
         "tag": "Room",
         "universalKey": undefined,
       },
     ],
-    "description": Array [
+    "description": [
       "Light streams in from the entrance. On one side of the cave is an old firepit and comfortably tamped-down earth floor. At the opposite end, a jumbled pile of jagged rocks against the wall make a far less hospitable space.",
     ],
     "key": undefined,
-    "name": Array [
+    "name": [
       "Shallow cave",
     ],
     "summary": undefined,
     "tag": "Example",
     "universalKey": "EXAMPLE#example2",
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "cave",
         "tag": "Room",
         "universalKey": undefined,
       },
     ],
-    "description": Array [
+    "description": [
       "Light streams in from the entrance. On one side of the cave is an old firepit and comfortably tamped-down earth floor. At the opposite end, rocks have been cleared revealing a passage further underground.",
     ],
     "key": undefined,
-    "name": Array [
+    "name": [
       "Shallow cave",
     ],
     "summary": undefined,
     "tag": "Example",
     "universalKey": "EXAMPLE#example3",
   },
-  Object {
+  {
     "context": undefined,
-    "examples": Array [
+    "examples": [
       "EXAMPLE#example5",
     ],
-    "exits": Array [
-      Object {
+    "exits": [
+      {
         "description": "passage",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "curvingPassage",
           "tag": "Room",
@@ -707,14 +707,14 @@ Array [
         },
       },
     ],
-    "features": Array [
-      Object {
+    "features": [
+      {
         "context": undefined,
         "key": "orc",
         "tag": "Feature",
         "universalKey": undefined,
       },
-      Object {
+      {
         "context": undefined,
         "key": "pie",
         "tag": "Feature",
@@ -726,9 +726,9 @@ Array [
     "tag": "Room",
     "universalKey": undefined,
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "chamber",
         "tag": "Room",
@@ -742,9 +742,9 @@ Array [
     "tag": "Example",
     "universalKey": "EXAMPLE#example5",
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "chamber",
         "tag": "Room",
@@ -756,9 +756,9 @@ Array [
     "tag": "Feature",
     "universalKey": undefined,
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "chamber",
         "tag": "Room",
@@ -770,24 +770,24 @@ Array [
     "tag": "Feature",
     "universalKey": undefined,
   },
-  Object {
+  {
     "context": undefined,
-    "examples": Array [
+    "examples": [
       "EXAMPLE#example4",
     ],
-    "exits": Array [
-      Object {
+    "exits": [
+      {
         "description": "cave",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "cave",
           "tag": "Room",
           "universalKey": undefined,
         },
       },
-      Object {
+      {
         "description": "chamber",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "chamber",
           "tag": "Room",
@@ -800,35 +800,35 @@ Array [
     "tag": "Room",
     "universalKey": undefined,
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "curvingPassage",
         "tag": "Room",
         "universalKey": undefined,
       },
     ],
-    "description": Array [
+    "description": [
       "Walls smoothly cut from the bedrock curve in a long arc, lit every few yards by a small sconce mounted above eye-level.",
     ],
     "key": undefined,
-    "name": Array [
+    "name": [
       "Curving Passage",
     ],
     "summary": undefined,
     "tag": "Example",
     "universalKey": "EXAMPLE#example4",
   },
-  Object {
+  {
     "context": undefined,
-    "examples": Array [
+    "examples": [
       "EXAMPLE#example1",
     ],
-    "exits": Array [
-      Object {
+    "exits": [
+      {
         "description": "cave",
-        "to": Object {
+        "to": {
           "context": undefined,
           "key": "cave",
           "tag": "Room",
@@ -841,39 +841,39 @@ Array [
     "tag": "Room",
     "universalKey": undefined,
   },
-  Object {
-    "context": Array [
-      Object {
+  {
+    "context": [
+      {
         "context": undefined,
         "key": "VORTEX",
         "tag": "Room",
         "universalKey": undefined,
       },
     ],
-    "description": Array [
+    "description": [
       "Natural rock formations rise in a jagged cliff-face. An asymmetric opening leads into a dimly lit cave.",
-      Object {
-        "children": Array [],
-        "data": Object {
+      {
+        "children": [],
+        "data": {
           "tag": "br",
         },
       },
       "(You could also go literally anywhere else in the world, if any of it had been created. But it hasn't)",
     ],
     "key": undefined,
-    "name": Array [
+    "name": [
       "Cave entrance",
     ],
     "summary": undefined,
     "tag": "Example",
     "universalKey": "EXAMPLE#example1",
   },
-  Object {
+  {
     "context": undefined,
-    "images": Array [
-      Object {
-        "children": Array [],
-        "data": Object {
+    "images": [
+      {
+        "children": [],
+        "data": {
           "key": "dungeonImage",
           "tag": "Image",
         },
@@ -881,9 +881,9 @@ Array [
     ],
     "key": "dungeonMap",
     "name": undefined,
-    "positions": Array [
-      Object {
-        "room": Object {
+    "positions": [
+      {
+        "room": {
           "context": undefined,
           "key": "VORTEX",
           "tag": "Room",
@@ -892,8 +892,8 @@ Array [
         "x": 0,
         "y": 250,
       },
-      Object {
-        "room": Object {
+      {
+        "room": {
           "context": undefined,
           "key": "cave",
           "tag": "Room",
@@ -902,8 +902,8 @@ Array [
         "x": 0,
         "y": 150,
       },
-      Object {
-        "room": Object {
+      {
+        "room": {
           "context": undefined,
           "key": "curvingPassage",
           "tag": "Room",
@@ -912,8 +912,8 @@ Array [
         "x": -150,
         "y": 100,
       },
-      Object {
-        "room": Object {
+      {
+        "room": {
           "context": undefined,
           "key": "chamber",
           "tag": "Room",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/comments.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/comments.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`commentTokenizer should tokenize a bounded comment 1`] = `
-Object {
+{
   "endIdx": 39,
   "startIdx": 0,
   "type": "Comment",
@@ -9,7 +9,7 @@ Object {
 `;
 
 exports[`commentTokenizer should tokenize a comment-to-end-of-line 1`] = `
-Object {
+{
   "endIdx": 14,
   "startIdx": 0,
   "type": "Comment",
@@ -17,7 +17,7 @@ Object {
 `;
 
 exports[`commentTokenizer should tokenize a comment-to-end-of-source 1`] = `
-Object {
+{
   "endIdx": 14,
   "startIdx": 0,
   "type": "Comment",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/description.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/description.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`descriptionTokenizer should break description for comments 1`] = `
-Object {
+{
   "endIdx": 4,
   "startIdx": 0,
   "type": "Description",
@@ -10,7 +10,7 @@ Object {
 `;
 
 exports[`descriptionTokenizer should break description for comments 2`] = `
-Object {
+{
   "endIdx": 11,
   "startIdx": 0,
   "type": "Description",
@@ -19,7 +19,7 @@ Object {
 `;
 
 exports[`descriptionTokenizer should tokenize to end of source 1`] = `
-Object {
+{
   "endIdx": 4,
   "startIdx": 0,
   "type": "Description",
@@ -28,7 +28,7 @@ Object {
 `;
 
 exports[`descriptionTokenizer should tokenize to the next tag 1`] = `
-Object {
+{
   "endIdx": 4,
   "startIdx": 0,
   "type": "Description",
@@ -37,7 +37,7 @@ Object {
 `;
 
 exports[`descriptionTokenizer should tokenize to the next whitespace 1`] = `
-Object {
+{
   "endIdx": 4,
   "startIdx": 0,
   "type": "Description",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/expression.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/expression.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`expressionTokenizer should properly nest expressions 1`] = `
-Object {
+{
   "endIdx": 62,
   "startIdx": 0,
   "type": "ExpressionValue",
@@ -10,16 +10,16 @@ Object {
 `;
 
 exports[`expressionTokenizer should properly nest string literals 1`] = `
-Object {
+{
   "endIdx": 28,
   "startIdx": 0,
   "type": "ExpressionValue",
-  "value": " return 'Test' + \\" value}\\" ",
+  "value": " return 'Test' + " value}" ",
 }
 `;
 
 exports[`expressionTokenizer should properly nest template literals 1`] = `
-Object {
+{
   "endIdx": 26,
   "startIdx": 0,
   "type": "ExpressionValue",
@@ -28,7 +28,7 @@ Object {
 `;
 
 exports[`expressionTokenizer templateStringSubTokenizer should not break on escaped quotes 1`] = `
-Object {
+{
   "endIdx": 9,
   "startIdx": 0,
   "type": "TemplateString",
@@ -36,7 +36,7 @@ Object {
 `;
 
 exports[`expressionTokenizer templateStringSubTokenizer should tokenize nested template strings 1`] = `
-Object {
+{
   "endIdx": 19,
   "startIdx": 0,
   "type": "TemplateString",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/index.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/index.test.ts.snap
@@ -1,38 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tokenizer should tokenize a single non-self-closing tag 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 4,
     "startIdx": 0,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 5,
     "startIdx": 5,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 9,
     "isBoolean": false,
     "key": "key",
     "startIdx": 6,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 14,
     "startIdx": 10,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 15,
     "selfClosing": false,
     "startIdx": 15,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 22,
     "startIdx": 16,
     "tag": "Room",
@@ -42,37 +42,37 @@ Array [
 `;
 
 exports[`tokenizer should tokenize a single self-closing tag 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 4,
     "startIdx": 0,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 5,
     "startIdx": 5,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 9,
     "isBoolean": false,
     "key": "key",
     "startIdx": 6,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 14,
     "startIdx": 10,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 15,
     "startIdx": 15,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 17,
     "selfClosing": true,
     "startIdx": 16,
@@ -82,144 +82,144 @@ Array [
 `;
 
 exports[`tokenizer should tokenize comments 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 5,
     "startIdx": 0,
     "tag": "Asset",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 6,
     "startIdx": 6,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 11,
     "isBoolean": false,
     "key": "uuid",
     "startIdx": 7,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 17,
     "startIdx": 12,
     "type": "KeyValue",
     "value": "Test",
   },
-  Object {
+  {
     "endIdx": 18,
     "selfClosing": false,
     "startIdx": 18,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 36,
     "startIdx": 32,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 37,
     "startIdx": 37,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 50,
     "startIdx": 38,
     "type": "Comment",
   },
-  Object {
+  {
     "endIdx": 51,
     "startIdx": 51,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 55,
     "isBoolean": false,
     "key": "key",
     "startIdx": 52,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 60,
     "startIdx": 56,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 61,
     "selfClosing": false,
     "startIdx": 61,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 90,
     "startIdx": 79,
     "tag": "Description",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 91,
     "selfClosing": false,
     "startIdx": 91,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 112,
     "startIdx": 92,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 129,
     "startIdx": 113,
     "type": "Description",
     "value": "Test description",
   },
-  Object {
+  {
     "endIdx": 137,
     "startIdx": 129,
     "type": "Comment",
   },
-  Object {
+  {
     "endIdx": 158,
     "startIdx": 138,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 171,
     "startIdx": 159,
     "type": "Comment",
   },
-  Object {
+  {
     "endIdx": 192,
     "startIdx": 172,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 204,
     "startIdx": 193,
     "type": "Description",
     "value": "End of test",
   },
-  Object {
+  {
     "endIdx": 220,
     "startIdx": 204,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 234,
     "startIdx": 221,
     "tag": "Description",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 254,
     "startIdx": 248,
     "tag": "Room",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 271,
     "startIdx": 264,
     "tag": "Asset",
@@ -229,188 +229,188 @@ Array [
 `;
 
 exports[`tokenizer should tokenize descriptions 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 5,
     "startIdx": 0,
     "tag": "Asset",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 6,
     "startIdx": 6,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 11,
     "isBoolean": false,
     "key": "uuid",
     "startIdx": 7,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 17,
     "startIdx": 12,
     "type": "KeyValue",
     "value": "Test",
   },
-  Object {
+  {
     "endIdx": 18,
     "selfClosing": false,
     "startIdx": 18,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 36,
     "startIdx": 32,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 37,
     "startIdx": 37,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 41,
     "isBoolean": false,
     "key": "key",
     "startIdx": 38,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 46,
     "startIdx": 42,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 47,
     "selfClosing": false,
     "startIdx": 47,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 76,
     "startIdx": 65,
     "tag": "Description",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 77,
     "selfClosing": false,
     "startIdx": 77,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 98,
     "startIdx": 78,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 104,
     "startIdx": 99,
     "tag": "Space",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 105,
     "startIdx": 105,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 107,
     "selfClosing": true,
     "startIdx": 106,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 128,
     "startIdx": 108,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 145,
     "startIdx": 129,
     "type": "Description",
     "value": "Test description",
   },
-  Object {
+  {
     "endIdx": 165,
     "startIdx": 145,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 170,
     "startIdx": 166,
     "tag": "Link",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 171,
     "startIdx": 171,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 175,
     "isBoolean": false,
     "key": "key",
     "startIdx": 172,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 180,
     "startIdx": 176,
     "type": "KeyValue",
     "value": "DEF",
   },
-  Object {
+  {
     "endIdx": 181,
     "selfClosing": false,
     "startIdx": 181,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 191,
     "startIdx": 182,
     "type": "Description",
     "value": "link text",
   },
-  Object {
+  {
     "endIdx": 197,
     "startIdx": 191,
     "tag": "Link",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 218,
     "startIdx": 198,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 230,
     "startIdx": 219,
     "type": "Description",
     "value": "End of test",
   },
-  Object {
+  {
     "endIdx": 246,
     "startIdx": 230,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 260,
     "startIdx": 247,
     "tag": "Description",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 280,
     "startIdx": 274,
     "tag": "Room",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 297,
     "startIdx": 290,
     "tag": "Asset",
@@ -420,98 +420,98 @@ Array [
 `;
 
 exports[`tokenizer should tokenize escaped characters in descriptions 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 5,
     "startIdx": 0,
     "tag": "Asset",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 6,
     "startIdx": 6,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 11,
     "isBoolean": false,
     "key": "uuid",
     "startIdx": 7,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 17,
     "startIdx": 12,
     "type": "KeyValue",
     "value": "Test",
   },
-  Object {
+  {
     "endIdx": 18,
     "selfClosing": false,
     "startIdx": 18,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 36,
     "startIdx": 32,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 37,
     "startIdx": 37,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 41,
     "isBoolean": false,
     "key": "key",
     "startIdx": 38,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 46,
     "startIdx": 42,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 47,
     "selfClosing": false,
     "startIdx": 47,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 76,
     "startIdx": 65,
     "tag": "Description",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 77,
     "selfClosing": false,
     "startIdx": 77,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 86,
     "startIdx": 78,
     "type": "Description",
-    "value": "\\\\ < >",
+    "value": "\\ < >",
   },
-  Object {
+  {
     "endIdx": 99,
     "startIdx": 86,
     "tag": "Description",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 119,
     "startIdx": 113,
     "tag": "Room",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 136,
     "startIdx": 129,
     "tag": "Asset",
@@ -521,109 +521,109 @@ Array [
 `;
 
 exports[`tokenizer should tokenize nested tags 1`] = `
-Array [
-  Object {
+[
+  {
     "endIdx": 5,
     "startIdx": 0,
     "tag": "Asset",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 6,
     "startIdx": 6,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 11,
     "isBoolean": false,
     "key": "uuid",
     "startIdx": 7,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 17,
     "startIdx": 12,
     "type": "KeyValue",
     "value": "Test",
   },
-  Object {
+  {
     "endIdx": 18,
     "selfClosing": false,
     "startIdx": 18,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 36,
     "startIdx": 32,
     "tag": "Room",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 37,
     "startIdx": 37,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 41,
     "isBoolean": false,
     "key": "key",
     "startIdx": 38,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 46,
     "startIdx": 42,
     "type": "KeyValue",
     "value": "ABC",
   },
-  Object {
+  {
     "endIdx": 47,
     "selfClosing": false,
     "startIdx": 47,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 72,
     "startIdx": 65,
     "tag": "Feature",
     "type": "TagOpenBegin",
   },
-  Object {
+  {
     "endIdx": 73,
     "startIdx": 73,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 77,
     "isBoolean": false,
     "key": "key",
     "startIdx": 74,
     "type": "Property",
   },
-  Object {
+  {
     "endIdx": 82,
     "startIdx": 78,
     "type": "KeyValue",
     "value": "DEF",
   },
-  Object {
+  {
     "endIdx": 83,
     "startIdx": 83,
     "type": "Whitespace",
   },
-  Object {
+  {
     "endIdx": 85,
     "selfClosing": true,
     "startIdx": 84,
     "type": "TagOpenEnd",
   },
-  Object {
+  {
     "endIdx": 105,
     "startIdx": 99,
     "tag": "Room",
     "type": "TagClose",
   },
-  Object {
+  {
     "endIdx": 122,
     "startIdx": 115,
     "tag": "Asset",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/key.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/key.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`keyValueTokenizer should accept a UUID 1`] = `
-Object {
+{
   "endIdx": 20,
   "startIdx": 0,
   "type": "KeyValue",
@@ -10,7 +10,7 @@ Object {
 `;
 
 exports[`keyValueTokenizer should accept periods in keys 1`] = `
-Object {
+{
   "endIdx": 10,
   "startIdx": 0,
   "type": "KeyValue",
@@ -19,7 +19,7 @@ Object {
 `;
 
 exports[`keyValueTokenizer should tokenize with whitespace around value 1`] = `
-Object {
+{
   "endIdx": 7,
   "startIdx": 0,
   "type": "KeyValue",
@@ -28,7 +28,7 @@ Object {
 `;
 
 exports[`keyValueTokenizer should tokenize without whitespace 1`] = `
-Object {
+{
   "endIdx": 7,
   "startIdx": 0,
   "type": "KeyValue",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/literal.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/literal.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`literalValueTokenizer should expect double-quoted expressions 1`] = `
-Object {
+{
   "endIdx": 5,
   "startIdx": 0,
   "type": "LiteralValue",
@@ -10,25 +10,25 @@ Object {
 `;
 
 exports[`literalValueTokenizer stringLiteralSubTokenizer should not break on escaped quotes 1`] = `
-Object {
+{
   "endIdx": 9,
   "startIdx": 0,
   "type": "LiteralValue",
-  "value": "\\\\'Test\\\\'",
+  "value": "\\'Test\\'",
 }
 `;
 
 exports[`literalValueTokenizer stringLiteralSubTokenizer should not break on other-numbered quotes 1`] = `
-Object {
+{
   "endIdx": 6,
   "startIdx": 0,
   "type": "LiteralValue",
-  "value": "\\"Test",
+  "value": ""Test",
 }
 `;
 
 exports[`literalValueTokenizer stringLiteralSubTokenizer should tokenize bounded double-quote string literal 1`] = `
-Object {
+{
   "endIdx": 5,
   "startIdx": 0,
   "type": "LiteralValue",
@@ -37,7 +37,7 @@ Object {
 `;
 
 exports[`literalValueTokenizer stringLiteralSubTokenizer should tokenize bounded single-quote string literal 1`] = `
-Object {
+{
   "endIdx": 5,
   "startIdx": 0,
   "type": "LiteralValue",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagClose.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagClose.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tagCloseTokenizer should tokenize tag close with whitespace 1`] = `
-Object {
+{
   "endIdx": 9,
   "startIdx": 0,
   "tag": "Room",
@@ -10,7 +10,7 @@ Object {
 `;
 
 exports[`tagCloseTokenizer should tokenize tag close without whitespace 1`] = `
-Object {
+{
   "endIdx": 6,
   "startIdx": 0,
   "tag": "Room",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagOpen.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagOpen.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tagOpenBeginTokenizer should tokenize tag open 1`] = `
-Object {
+{
   "endIdx": 4,
   "startIdx": 0,
   "tag": "Room",
@@ -10,7 +10,7 @@ Object {
 `;
 
 exports[`tagOpenEndTokenizer should tokenize non-self-closing tag close 1`] = `
-Object {
+{
   "endIdx": 0,
   "selfClosing": false,
   "startIdx": 0,
@@ -19,7 +19,7 @@ Object {
 `;
 
 exports[`tagOpenEndTokenizer should tokenize self-closing tag close 1`] = `
-Object {
+{
   "endIdx": 1,
   "selfClosing": true,
   "startIdx": 0,

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagProperty.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/tagProperty.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`tagPropertyTokenizer should fail with whitespace within value 1`] = `
-Object {
+{
   "endIdx": 5,
   "isBoolean": false,
   "key": "Test",
@@ -11,7 +11,7 @@ Object {
 `;
 
 exports[`tagPropertyTokenizer should tokenize false boolean properties 1`] = `
-Object {
+{
   "endIdx": 4,
   "isBoolean": true,
   "key": "Test",
@@ -23,7 +23,7 @@ Object {
 `;
 
 exports[`tagPropertyTokenizer should tokenize true boolean properties 1`] = `
-Object {
+{
   "endIdx": 4,
   "isBoolean": true,
   "key": "Test",
@@ -34,7 +34,7 @@ Object {
 `;
 
 exports[`tagPropertyTokenizer should tokenize without whitespace 1`] = `
-Object {
+{
   "endIdx": 4,
   "isBoolean": false,
   "key": "Test",

--- a/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/whiteSpace.test.ts.snap
+++ b/packages/mtw-wml/ts/parser/tokenizer/__snapshots__/whiteSpace.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`whiteSpaceTokenizer should tokenize whitespace between tags 1`] = `
-Object {
+{
   "endIdx": 5,
   "startIdx": 0,
   "type": "Whitespace",
@@ -9,7 +9,7 @@ Object {
 `;
 
 exports[`whiteSpaceTokenizer should tokenize whitespace to end of source 1`] = `
-Object {
+{
   "endIdx": 6,
   "startIdx": 0,
   "type": "Whitespace",

--- a/packages/mtw-wml/ts/schema/converters/components.test.ts
+++ b/packages/mtw-wml/ts/schema/converters/components.test.ts
@@ -92,7 +92,24 @@ describe('Parent tag', () => {
             expect(() => schemaFromParse(testParse)).toThrow('Parent tag content must be a ComponentUUID, got: not-a-valid-uuid')
         })
 
-        it('should reject Parent tag with empty content', () => {
+        it('should accept empty Parent tag (self-closing)', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Parent />
+                    </Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+            expect(parentNode?.children.length).toBe(0)
+        })
+
+        it('should accept empty Parent tag (opening and closing)', () => {
             const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
                 <Asset uuid=(Test)>
                     <Room key=(room1)>
@@ -100,7 +117,13 @@ describe('Parent tag', () => {
                     </Room>
                 </Asset>
             `))))
-            expect(() => schemaFromParse(testParse)).toThrow('Parent tag content must be a ComponentUUID')
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+            expect(parentNode?.children.length).toBe(0)
         })
 
         it('should reject Parent tag with properties', () => {
@@ -144,6 +167,24 @@ describe('Parent tag', () => {
             `)
             expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(testWML)
         })
+
+        it('should round-trip empty Parent tag (self-closing)', () => {
+            const testWML = deIndentWML(`
+                <Asset uuid=(Test)><Room key=(room1)><Parent /></Room></Asset>
+            `)
+            expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(testWML)
+        })
+
+        it('should round-trip empty Parent tag (opening and closing)', () => {
+            const testWML = deIndentWML(`
+                <Asset uuid=(Test)><Room key=(room1)><Parent></Parent></Room></Asset>
+            `)
+            // Empty tags should serialize as self-closing
+            const expectedWML = deIndentWML(`
+                <Asset uuid=(Test)><Room key=(room1)><Parent /></Room></Asset>
+            `)
+            expect(schemaToWML(schemaFromParse(parse(tokenizer(new SourceStream(testWML)))))).toEqual(expectedWML)
+        })
     })
 
     describe('edge cases', () => {
@@ -182,6 +223,25 @@ describe('Parent tag', () => {
             expect(parentNode).toBeDefined()
             const nameNode = roomNode?.children.find(({ data }) => data.tag === 'Name')
             expect(nameNode).toBeDefined()
+        })
+
+        it('should allow empty Parent tag alongside other content', () => {
+            const testParse = parse(tokenizer(new SourceStream(deIndentWML(`
+                <Asset uuid=(Test)>
+                    <Room key=(room1)>
+                        <Name>Test Room</Name>
+                        <Parent />
+                        <Description>Room description</Description>
+                    </Room>
+                </Asset>
+            `))))
+            const schema = schemaFromParse(testParse)
+            const roomNode = schema[0].children.find(({ data }) => data.tag === 'Room')
+            expect(roomNode).toBeDefined()
+            const parentNode = roomNode?.children.find(({ data }) => data.tag === 'Parent')
+            expect(parentNode).toBeDefined()
+            expect(isSchemaParent(parentNode?.data)).toBe(true)
+            expect(parentNode?.children.length).toBe(0)
         })
     })
 })

--- a/packages/mtw-wml/ts/schema/converters/components.ts
+++ b/packages/mtw-wml/ts/schema/converters/components.ts
@@ -59,6 +59,10 @@ const parentTagRenderLiteral = ({ tag: { data: tag, children }, ...args }: Print
     if (!isSchemaParent(tag)) {
         return [{ printMode: PrintMode.naive, output: '' }]
     }
+    // Handle empty Parent tags (self-closing)
+    if (children.length === 0) {
+        return [{ printMode: PrintMode.naive, output: `<${tag.tag} />` }]
+    }
     const textValue = children.map(({ data }) => (data)).filter(isSchemaString).map(({ value }) => (value)).join('') as string
     const naive = `<${tag.tag}>${textValue}</${tag.tag}>`
     if (naive.length + Math.min(10, args.options.indent * 4) > 80) {
@@ -120,7 +124,14 @@ export const componentConverters: Record<string, ConverterMapEntry> = {
             if (!isSchemaParent(initialTag)) {
                 throw new Error('Type mismatch on schema finalize')
             }
-            // Validate that the combined string content is a ComponentUUID
+            // Allow empty Parent tags (to express "no parent")
+            if (children.length === 0) {
+                return {
+                    data: { tag: 'Parent' },
+                    children: []
+                }
+            }
+            // If not empty, validate that the combined string content is a ComponentUUID
             const textValue = children
                 .map(({ data }) => data)
                 .filter(isSchemaString)


### PR DESCRIPTION
…est version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows empty Parent tags (rendered self-closing) and updates snapshots to new Jest output format.
> 
> - **Schema/Converters (`components.ts`)**:
>   - Support empty `Parent` tags: accept with no children, validate in `finalize`, and render as self-closing.
>   - Enforce no properties on `Parent`; keep existing UUID validation when content is present.
> - **Tests (`components.test.ts`)**:
>   - Add parsing/validation/serialization tests for empty `Parent` (self-closing and open/close) and coexistence with other content.
>   - Round-trip expectations updated (empty `Parent` serializes self-closing).
> - **Snapshots**:
>   - Refresh tokenizer/dungeon snapshots to new Jest formatting (object/array literals, escaping changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64b8f920ead78a78cfb994ef1609d38b516758c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->