### PR TITLE
ISS6437: Added StandardExplicitParent class

### DIFF
--- a/packages/mtw-wml/ts/standardize/explicit/index.ts
+++ b/packages/mtw-wml/ts/standardize/explicit/index.ts
@@ -1,0 +1,2 @@
+export { StandardExplicitParent } from './parent'
+

--- a/packages/mtw-wml/ts/standardize/explicit/parent.test.ts
+++ b/packages/mtw-wml/ts/standardize/explicit/parent.test.ts
@@ -1,0 +1,315 @@
+import { StandardExplicitParent, StandardExplicitParentSimple, StandardExplicitParentRemove, StandardExplicitParentReplace } from './parent'
+import { ComponentUUID } from '@tonylb/mtw-base/ts/schema'
+import { MergeConflictError } from '@tonylb/mtw-base/ts/standardize'
+
+describe('StandardExplicitParent', () => {
+    const validComponentUUID: ComponentUUID = 'ROOM#test-room'
+    const anotherComponentUUID: ComponentUUID = 'FEATURE#test-feature'
+
+    describe('construction', () => {
+        it('should create a StandardExplicitParentSimple from ComponentUUID', () => {
+            const parent = new StandardExplicitParent(validComponentUUID)
+            expect(parent._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(parent.toJSON()).toBe(validComponentUUID)
+        })
+
+        it('should create a StandardExplicitParentRemove from Remove structure', () => {
+            const parent = new StandardExplicitParent({ tag: 'Remove', match: validComponentUUID })
+            expect(parent._payload).toBeInstanceOf(StandardExplicitParentRemove)
+            expect(parent.toJSON()).toEqual({ tag: 'Remove', match: validComponentUUID })
+        })
+
+        it('should create a StandardExplicitParentReplace from Replace structure', () => {
+            const parent = new StandardExplicitParent({ 
+                tag: 'Replace', 
+                match: validComponentUUID, 
+                payload: anotherComponentUUID 
+            })
+            expect(parent._payload).toBeInstanceOf(StandardExplicitParentReplace)
+            expect(parent.toJSON()).toEqual({ 
+                tag: 'Replace', 
+                match: validComponentUUID, 
+                payload: anotherComponentUUID 
+            })
+        })
+
+        it('should handle empty Parent tag (no parent)', () => {
+            const parent = new StandardExplicitParent([])
+            expect(parent._payload).toBeUndefined()
+            expect(parent.toJSON()).toBeUndefined()
+            expect(parent.schema).toEqual([{ data: { tag: 'Parent' }, children: [] }])
+        })
+
+        it('should create from WML schema with Parent tag', () => {
+            const parent = new StandardExplicitParent([
+                { data: { tag: 'Parent' }, children: [
+                    { data: { tag: 'String', value: validComponentUUID }, children: [] }
+                ]}
+            ])
+            expect(parent._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(parent.toJSON()).toBe(validComponentUUID)
+        })
+    })
+
+    describe('merge operations', () => {
+        it('should merge two identical StandardExplicitParentSimple instances', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent(validComponentUUID)
+            const merged = parent1.merge(parent2)
+            expect(merged).toBeInstanceOf(StandardExplicitParent)
+            expect(merged?._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(merged?.toJSON()).toBe(validComponentUUID)
+        })
+
+        it('should merge two different StandardExplicitParentSimple instances (replace)', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent(anotherComponentUUID)
+            const merged = parent1.merge(parent2)
+            expect(merged).toBeInstanceOf(StandardExplicitParent)
+            expect(merged?._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(merged?.toJSON()).toBe(anotherComponentUUID)
+        })
+
+        it('should merge Remove with Simple (exact match)', () => {
+            const parent1 = new StandardExplicitParent({ tag: 'Remove', match: validComponentUUID })
+            const parent2 = new StandardExplicitParent(validComponentUUID)
+            const merged = parent1.merge(parent2)
+            // Remove + Add with exact match should cancel out
+            expect(merged).toBeUndefined()
+        })
+
+        it('should throw error when merging Remove with Simple (no exact match)', () => {
+            const parent1 = new StandardExplicitParent({ tag: 'Remove', match: validComponentUUID })
+            const parent2 = new StandardExplicitParent(anotherComponentUUID)
+            expect(() => parent1.merge(parent2)).toThrow(MergeConflictError)
+            expect(() => parent1.merge(parent2)).toThrow('Parent values can only be removed or replaced if they match exactly')
+        })
+
+        it('should merge empty with Simple', () => {
+            const parent1 = new StandardExplicitParent([])
+            const parent2 = new StandardExplicitParent(validComponentUUID)
+            const merged = parent1.merge(parent2)
+            expect(merged).toBeInstanceOf(StandardExplicitParent)
+            expect(merged?.toJSON()).toBe(validComponentUUID)
+        })
+
+        it('should merge Simple with empty', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent([])
+            const merged = parent1.merge(parent2)
+            expect(merged).toBeInstanceOf(StandardExplicitParent)
+            expect(merged?.toJSON()).toBe(validComponentUUID)
+        })
+
+        it('should merge empty with empty', () => {
+            const parent1 = new StandardExplicitParent([])
+            const parent2 = new StandardExplicitParent([])
+            const merged = parent1.merge(parent2)
+            expect(merged).toBeUndefined()
+        })
+    })
+
+    describe('diff operations', () => {
+        it('should diff two identical StandardExplicitParentSimple instances', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent(validComponentUUID)
+            const diff = parent1.diff(parent2)
+            expect(diff).toBeUndefined()
+        })
+
+        it('should diff two different StandardExplicitParentSimple instances', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent(anotherComponentUUID)
+            const diff = parent1.diff(parent2)
+            expect(diff).toBeInstanceOf(StandardExplicitParent)
+            expect(diff?._payload).toBeInstanceOf(StandardExplicitParentReplace)
+            expect(diff?.toJSON()).toEqual({ 
+                tag: 'Replace', 
+                match: validComponentUUID, 
+                payload: anotherComponentUUID 
+            })
+        })
+
+        it('should diff Simple with empty', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const parent2 = new StandardExplicitParent([])
+            const diff = parent1.diff(parent2)
+            expect(diff).toBeInstanceOf(StandardExplicitParent)
+            expect(diff?._payload).toBeInstanceOf(StandardExplicitParentRemove)
+            expect(diff?.toJSON()).toEqual({ tag: 'Remove', match: validComponentUUID })
+        })
+
+        it('should diff empty with Simple', () => {
+            const parent1 = new StandardExplicitParent([])
+            const parent2 = new StandardExplicitParent(validComponentUUID)
+            const diff = parent1.diff(parent2)
+            expect(diff).toBeInstanceOf(StandardExplicitParent)
+            expect(diff?._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(diff?.toJSON()).toBe(validComponentUUID)
+        })
+
+        it('should diff empty with undefined', () => {
+            const parent1 = new StandardExplicitParent([])
+            const diff = parent1.diff(undefined)
+            expect(diff).toBeUndefined()
+        })
+
+        it('should diff Simple with undefined', () => {
+            const parent1 = new StandardExplicitParent(validComponentUUID)
+            const diff = parent1.diff(undefined)
+            expect(diff).toBeInstanceOf(StandardExplicitParent)
+            expect(diff?._payload).toBeInstanceOf(StandardExplicitParentRemove)
+            expect(diff?.toJSON()).toEqual({ tag: 'Remove', match: validComponentUUID })
+        })
+    })
+
+    describe('mapContents operations', () => {
+        it('should map contents of StandardExplicitParentSimple', () => {
+            const parent = new StandardExplicitParent(validComponentUUID)
+            const mapped = parent.mapContents(data => 'FEATURE#mapped-feature' as ComponentUUID)
+            expect(mapped).toBeInstanceOf(StandardExplicitParent)
+            expect(mapped._payload).toBeInstanceOf(StandardExplicitParentSimple)
+            expect(mapped.toJSON()).toBe('FEATURE#mapped-feature')
+        })
+
+        it('should map contents of StandardExplicitParentRemove', () => {
+            const parent = new StandardExplicitParent({ tag: 'Remove', match: validComponentUUID })
+            const mapped = parent.mapContents(data => 'FEATURE#mapped-feature' as ComponentUUID)
+            expect(mapped).toBeInstanceOf(StandardExplicitParent)
+            expect(mapped._payload).toBeInstanceOf(StandardExplicitParentRemove)
+            expect(mapped.toJSON()).toEqual({ tag: 'Remove', match: 'FEATURE#mapped-feature' })
+        })
+
+        it('should map contents of StandardExplicitParentReplace', () => {
+            const parent = new StandardExplicitParent({ 
+                tag: 'Replace', 
+                match: validComponentUUID, 
+                payload: anotherComponentUUID 
+            })
+            const mapped = parent.mapContents(data => 'FEATURE#mapped-feature' as ComponentUUID)
+            expect(mapped).toBeInstanceOf(StandardExplicitParent)
+            expect(mapped._payload).toBeInstanceOf(StandardExplicitParentReplace)
+            expect(mapped.toJSON()).toEqual({ 
+                tag: 'Replace', 
+                match: 'FEATURE#mapped-feature', 
+                payload: 'FEATURE#mapped-feature' 
+            })
+        })
+
+        it('should handle mapContents on empty Parent', () => {
+            const parent = new StandardExplicitParent([])
+            const mapped = parent.mapContents(data => 'FEATURE#mapped-feature' as ComponentUUID)
+            expect(mapped).toBeInstanceOf(StandardExplicitParent)
+            expect(mapped._payload).toBeUndefined()
+            expect(mapped.toJSON()).toBeUndefined()
+        })
+    })
+
+    describe('schema generation', () => {
+        it('should generate correct schema for Simple', () => {
+            const parent = new StandardExplicitParent(validComponentUUID)
+            const schema = parent.schema
+            expect(schema).toEqual([
+                { 
+                    data: { tag: 'Parent' }, 
+                    children: [
+                        { data: { tag: 'String', value: validComponentUUID }, children: [] }
+                    ]
+                }
+            ])
+        })
+
+        it('should generate correct schema for Remove', () => {
+            const parent = new StandardExplicitParent({ tag: 'Remove', match: validComponentUUID })
+            const schema = parent.schema
+            expect(schema).toEqual([
+                { 
+                    data: { tag: 'Remove' }, 
+                    children: [
+                        { 
+                            data: { tag: 'Parent' }, 
+                            children: [
+                                { data: { tag: 'String', value: validComponentUUID }, children: [] }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        })
+
+        it('should generate correct schema for Replace', () => {
+            const parent = new StandardExplicitParent({ 
+                tag: 'Replace', 
+                match: validComponentUUID, 
+                payload: anotherComponentUUID 
+            })
+            const schema = parent.schema
+            expect(schema).toEqual([
+                { 
+                    data: { tag: 'Replace' }, 
+                    children: [
+                        { 
+                            data: { tag: 'ReplaceMatch' }, 
+                            children: [
+                                { 
+                                    data: { tag: 'Parent' }, 
+                                    children: [
+                                        { data: { tag: 'String', value: validComponentUUID }, children: [] }
+                                    ]
+                                }
+                            ]
+                        },
+                        { 
+                            data: { tag: 'ReplacePayload' }, 
+                            children: [
+                                { 
+                                    data: { tag: 'Parent' }, 
+                                    children: [
+                                        { data: { tag: 'String', value: anotherComponentUUID }, children: [] }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        })
+
+        it('should generate correct schema for empty Parent', () => {
+            const parent = new StandardExplicitParent([])
+            const schema = parent.schema
+            expect(schema).toEqual([
+                { data: { tag: 'Parent' }, children: [] }
+            ])
+        })
+
+        it('should generate correct nestedSchema', () => {
+            const parent = new StandardExplicitParent(validComponentUUID)
+            const nested = parent.nestedSchema({ tag: 'Room', key: 'test' })
+            expect(nested).toEqual([
+                { 
+                    data: { tag: 'Room', key: 'test' }, 
+                    children: [
+                        { 
+                            data: { tag: 'Parent' }, 
+                            children: [
+                                { data: { tag: 'String', value: validComponentUUID }, children: [] }
+                            ]
+                        }
+                    ]
+                }
+            ])
+        })
+    })
+
+    describe('error cases', () => {
+        it('should throw error when payloadFactory receives invalid ComponentUUID', () => {
+            expect(() => {
+                new StandardExplicitParent([
+                    { data: { tag: 'String', value: 'not-a-valid-uuid' }, children: [] }
+                ])
+            }).toThrow('Parent tag content must be a ComponentUUID')
+        })
+    })
+})
+

--- a/packages/mtw-wml/ts/standardize/explicit/parent.ts
+++ b/packages/mtw-wml/ts/standardize/explicit/parent.ts
@@ -1,0 +1,394 @@
+import { GenericTree } from "@tonylb/mtw-base/ts/genericTree"
+import { StandardEditableDataDelta, standardEditableFactory, StandardEditablePayload, StandardEditableWrapper } from "../../generics/editable"
+import { SchemaTag } from "@tonylb/mtw-base/ts/schema"
+import { MergeConflictError } from "@tonylb/mtw-base/ts/standardize"
+import { StandardEditableData } from "@tonylb/mtw-base/ts/editable"
+import { isRenderTree, RenderTree, renderTreeToSchema } from "@tonylb/mtw-base/ts/renderTree"
+import { isSchemaString } from "@tonylb/mtw-base/ts/schema/renderTree"
+import { ComponentUUID, isSchemaComponentUUID } from "@tonylb/mtw-base/ts/schema"
+
+//
+// StandardExplicitParentSimpleBase holds the contents for a simple StandardExplicitParent
+//
+export class StandardExplicitParentSimpleBase implements StandardEditablePayload<ComponentUUID> {
+    data: ComponentUUID
+    get schema() {
+        return [{ data: { tag: 'String' as const, value: this.data }, children: [] }]
+    }
+    constructor(data: ComponentUUID) {
+        if (!isSchemaComponentUUID(data)) {
+            throw new Error(`Invalid ComponentUUID: ${data}`)
+        }
+        this.data = data
+    }
+    clone() {
+        return new StandardExplicitParentSimpleBase(this.data)
+    }
+    toJSON: () => ComponentUUID = () => this.data
+}
+
+const payloadFactory = (props: ComponentUUID | GenericTree<SchemaTag>): StandardExplicitParentSimpleBase | undefined => {
+    if (typeof props === 'string' && isSchemaComponentUUID(props)) {
+        return new StandardExplicitParentSimpleBase(props)
+    }
+    // Handle schema tree - check if first element is a Parent tag
+    if (Array.isArray(props) && props.length > 0) {
+        const firstElement = props[0]
+        // If first element is a Parent tag, extract its children
+        if (firstElement.data && firstElement.data.tag === 'Parent') {
+            const parentChildren = firstElement.children
+            // Combine all String children from Parent tag
+            const combinedValue = parentChildren
+                .map(({ data }) => data)
+                .filter(isSchemaString)
+                .map(({ value }) => value)
+                .join('')
+            if (combinedValue && isSchemaComponentUUID(combinedValue)) {
+                return new StandardExplicitParentSimpleBase(combinedValue)
+            }
+            // Empty Parent tag (self-closing)
+            if (combinedValue === '') {
+                return undefined
+            }
+            throw new Error(`Parent tag content must be a ComponentUUID, got: ${combinedValue}`)
+        }
+        // Handle direct String tag (not wrapped in Parent)
+        if (props.length === 1 && isSchemaString(props[0].data)) {
+            const combinedValue = props[0].data.value
+            if (isSchemaComponentUUID(combinedValue)) {
+                return new StandardExplicitParentSimpleBase(combinedValue)
+            }
+            throw new Error(`Parent tag content must be a ComponentUUID, got: ${combinedValue}`)
+        }
+    }
+    // Handle empty Parent tag (self-closing) - return undefined to represent no parent
+    if (Array.isArray(props) && props.length === 0) {
+        return undefined
+    }
+    throw new Error('Invalid argument in StandardExplicitParentSimpleBase constructor')
+}
+
+// Parent values can only be added if they match exactly (no partial matches)
+const standardExplicitParentAdd = (base: ComponentUUID, incoming: ComponentUUID): ComponentUUID => {
+    // For Parent, adding means replacing - they must match exactly
+    if (base === incoming) {
+        return base
+    }
+    // If they don't match, the incoming value replaces the base
+    return incoming
+}
+
+// Parent values can only be removed if they match exactly (no partial matches)
+const standardExplicitParentSubtract = (base: ComponentUUID, incoming: ComponentUUID): { add?: ComponentUUID, remove?: ComponentUUID } => {
+    // Only allow exact matches - partial matches are error conditions
+    if (base === incoming) {
+        // Exact match: remove the value entirely
+        return {}
+    }
+    // Partial matches are not allowed for Parent values
+    throw new MergeConflictError('Parent values can only be removed or replaced if they match exactly. Partial matches are not allowed.')
+}
+
+// Parent values can only be diffed if they match exactly (no partial matches)
+const standardExplicitParentDiff = (base: ComponentUUID, incoming: ComponentUUID): { add?: ComponentUUID, remove?: ComponentUUID } => {
+    if (base === incoming) {
+        // No difference
+        return {}
+    }
+    // Different values: replace base with incoming
+    return { remove: base, add: incoming }
+}
+
+export const { constructorDelta: factory, typeguard: isStandardExplicitParentData, merge, diff } = standardEditableFactory({
+    typeguard: (value: any): value is ComponentUUID => (typeof value === 'string' && isSchemaComponentUUID(value)),
+    payloadFactory: payloadFactory,
+    payload: StandardExplicitParentSimpleBase,
+    add: standardExplicitParentAdd,
+    subtract: standardExplicitParentSubtract,
+    diff: standardExplicitParentDiff
+})
+
+const fromDelta = (delta: { add?: ComponentUUID, remove?: ComponentUUID }): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined => {
+    const { add, remove } = delta
+    if (add) {
+        if (remove) {
+            return new StandardExplicitParentReplace(new StandardExplicitParentSimpleBase(remove), new StandardExplicitParentSimpleBase(add))
+        }
+        return new StandardExplicitParentSimple(new StandardExplicitParentSimpleBase(add))
+    }
+    if (remove) {
+        return new StandardExplicitParentRemove(new StandardExplicitParentSimpleBase(remove))
+    }
+    return undefined
+}
+
+export class StandardExplicitParentSimple implements StandardEditableWrapper<StandardExplicitParentSimpleBase> {
+    payload: StandardExplicitParentSimpleBase
+    constructor(data: StandardExplicitParentSimpleBase | StandardEditableData<ComponentUUID> | RenderTree | GenericTree<SchemaTag> | ComponentUUID) {
+        if (data instanceof StandardExplicitParentSimpleBase) {
+            this.payload = data
+            return
+        }
+        const delta = factory(isRenderTree(data) ? renderTreeToSchema(data) : data)
+        if (delta && delta.add && !delta.remove) {
+            this.payload = delta.add
+            return
+        }
+        throw new Error('Invalid data in StandardExplicitParentSimple')
+    }
+    get schema() {
+        return [{ data: { tag: 'Parent' as const }, children: this.payload.schema }]
+    }
+    nestedSchema(tag) {
+        return [{ data: tag, children: this.schema }]
+    }
+    get _delta(): StandardEditableDataDelta<ComponentUUID> {
+        return { add: this.payload.toJSON() }
+    }
+    clone() {
+        return new StandardExplicitParentSimple(this.payload)
+    }
+    toJSON: () => StandardEditableData<ComponentUUID> = () => this.payload.toJSON()
+    get plain() { return this.payload }
+    merge(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(merge(this._delta, other._delta))
+    }
+    diff(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(diff(this._delta, other._delta))
+    }
+}
+
+export class StandardExplicitParentRemove implements StandardEditableWrapper<StandardExplicitParentSimpleBase> {
+    match: StandardExplicitParentSimpleBase
+    constructor(data: StandardExplicitParentSimpleBase | StandardEditableData<ComponentUUID> | RenderTree | GenericTree<SchemaTag> | ComponentUUID) {
+        if (data instanceof StandardExplicitParentSimpleBase) {
+            this.match = data
+            return
+        }
+        const delta = factory(isRenderTree(data) ? renderTreeToSchema(data) : data)
+        if (delta && !delta.add && delta.remove) {
+            this.match = delta.remove
+            return
+        }
+        console.log(`Invalid data: ${JSON.stringify(data)}`)
+        throw new Error('Invalid data in StandardExplicitParentRemove')
+    }
+    get schema() {
+        return [{ data: { tag: 'Remove' as const }, children: [{ data: { tag: 'Parent' as const }, children: this.match.schema }] }]
+    }
+    nestedSchema(tag) {
+        return [{
+            data: { tag: 'Remove' as const },
+            children: [{ data: tag, children: [{ data: { tag: 'Parent' as const }, children: this.match.schema }] }]
+        }]
+    }
+    get _delta(): StandardEditableDataDelta<ComponentUUID> {
+        return { remove: this.match.toJSON() }
+    }
+    clone() {
+        return new StandardExplicitParentRemove(this.match)
+    }
+    toJSON: () => StandardEditableData<ComponentUUID> = () => ({ tag: 'Remove' as const, match: this.match.toJSON() })
+    get plain() { return this.match }
+    merge(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(merge(this._delta, other._delta))
+    }
+    diff(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(diff(this._delta, other._delta))
+    }
+}
+
+export class StandardExplicitParentReplace implements StandardEditableWrapper<StandardExplicitParentSimpleBase> {
+    match: StandardExplicitParentSimpleBase
+    payload: StandardExplicitParentSimpleBase
+    constructor(...args: [StandardEditableData<ComponentUUID> | RenderTree | GenericTree<SchemaTag> | ComponentUUID] | [StandardExplicitParentSimpleBase, StandardExplicitParentSimpleBase]) {
+        if (args.length === 2) {
+            this.match = args[0]
+            this.payload = args[1]
+            return
+        }
+        const delta = factory(isRenderTree(args[0]) ? renderTreeToSchema(args[0]) : args[0])
+        if (delta && delta.add && delta.remove) {
+            this.match = delta.remove
+            this.payload = delta.add
+            return
+        }
+        throw new Error('Invalid data in StandardExplicitParentReplace')
+    }
+    get schema() {
+        return [{ data: { tag: 'Replace' as const }, children: [
+            { data: { tag: 'ReplaceMatch' as const }, children: [{ data: { tag: 'Parent' as const }, children: this.match.schema }] },
+            { data: { tag: 'ReplacePayload' as const }, children: [{ data: { tag: 'Parent' as const }, children: this.payload.schema }] }
+        ] }]
+    }
+    nestedSchema(tag) {
+        return [{
+            data: { tag: 'Replace' as const },
+            children: [
+                {
+                    data: { tag: 'ReplaceMatch' as const },
+                    children: [{ data: tag, children: [{ data: { tag: 'Parent' as const }, children: this.match.schema }] }]
+                },
+                {
+                    data: { tag: 'ReplacePayload' as const },
+                    children: [{ data: tag, children: [{ data: { tag: 'Parent' as const }, children: this.payload.schema }] }]
+                }
+            ]
+        }]
+    }
+    get _delta(): StandardEditableDataDelta<ComponentUUID> {
+        return { remove: this.match.toJSON(), add: this.payload.toJSON() }
+    }
+    clone() {
+        return new StandardExplicitParentReplace(this.match, this.payload)
+    }
+    toJSON: () => StandardEditableData<ComponentUUID> = () => ({ 
+        tag: 'Replace' as const,
+        match: this.match.toJSON(),
+        payload: this.payload.toJSON()
+    })
+    get plain() { return this.payload }
+    merge(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(merge(this._delta, other._delta))
+    }
+    diff(other: StandardEditableWrapper<StandardExplicitParentSimpleBase>): StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace | undefined {
+        return fromDelta(diff(this._delta, other._delta))
+    }
+}
+
+export class StandardExplicitParent {
+    _payload: StandardExplicitParentSimple | StandardExplicitParentRemove | StandardExplicitParentReplace;
+    
+    constructor(arg: any) {
+        if (arg instanceof StandardExplicitParentSimple || arg instanceof StandardExplicitParentRemove || arg instanceof StandardExplicitParentReplace) {
+            this._payload = arg
+            return
+        }
+        const delta = factory(isRenderTree(arg) ? renderTreeToSchema(arg) : arg)
+        if (!delta) {
+            // Handle empty Parent tag (self-closing) - represents no parent
+            // Return undefined payload to indicate no parent value
+            this._payload = undefined as any
+            return
+        }
+        if (delta.add) {
+            if (delta.remove) {
+                this._payload = new StandardExplicitParentReplace(arg)
+                return
+            }
+            this._payload = new StandardExplicitParentSimple(arg)
+            return
+        }
+        if (delta.remove) {
+            this._payload = new StandardExplicitParentRemove(arg)
+            return
+        }
+        // Empty delta - no parent value
+        this._payload = undefined as any
+    }
+
+    get schema(): GenericTree<SchemaTag> {
+        if (!this._payload) {
+            // Empty Parent tag (self-closing)
+            return [{ data: { tag: 'Parent' as const }, children: [] }]
+        }
+        return this._payload.schema
+    }
+
+    nestedSchema(tag: SchemaTag): GenericTree<SchemaTag> {
+        if (!this._payload) {
+            return [{ data: tag, children: [{ data: { tag: 'Parent' as const }, children: [] }] }]
+        }
+        return this._payload.nestedSchema(tag)
+    }
+
+    toJSON(): StandardEditableData<ComponentUUID> | undefined {
+        if (!this._payload) {
+            return undefined
+        }
+        return this._payload.toJSON()
+    }
+
+    merge(incoming: StandardExplicitParent): StandardExplicitParent | undefined {
+        if (!this._payload && !incoming._payload) {
+            return undefined
+        }
+        if (!this._payload) {
+            return incoming
+        }
+        if (!incoming._payload) {
+            return this
+        }
+        // Check for Remove + Add mismatch (Parent-specific constraint)
+        const thisDelta = this._payload._delta
+        const incomingDelta = incoming._payload._delta
+        if (thisDelta.remove && incomingDelta.add && thisDelta.remove !== incomingDelta.add) {
+            // For Parent values, Remove + Add with different values is an error
+            throw new MergeConflictError('Parent values can only be removed or replaced if they match exactly. Partial matches are not allowed.')
+        }
+        if (incomingDelta.remove && thisDelta.add && incomingDelta.remove !== thisDelta.add) {
+            // For Parent values, Remove + Add with different values is an error
+            throw new MergeConflictError('Parent values can only be removed or replaced if they match exactly. Partial matches are not allowed.')
+        }
+        const merged = this._payload.merge(incoming._payload)
+        if (merged) {
+            return new StandardExplicitParent(merged)
+        }
+        return undefined
+    }
+    diff(incoming: StandardExplicitParent | undefined): StandardExplicitParent | undefined {
+        if (!incoming) {
+            if (this._payload) {
+                const reversedDelta = this._payload._delta
+                if (reversedDelta) {
+                    if (reversedDelta.add) {
+                        return new StandardExplicitParent(new StandardExplicitParentRemove(new StandardExplicitParentSimpleBase(reversedDelta.add)))
+                    }
+                    if (reversedDelta.remove) {
+                        return new StandardExplicitParent(new StandardExplicitParentSimple(new StandardExplicitParentSimpleBase(reversedDelta.remove)))
+                    }
+                }
+            }
+            return undefined
+        }
+        if (!this._payload && !incoming._payload) {
+            return undefined
+        }
+        if (!this._payload) {
+            // This has no parent, incoming has a parent - return incoming as the diff
+            return incoming
+        }
+        if (!incoming._payload) {
+            // This has a parent, incoming has no parent - return removal of this
+            const reversedDelta = this._payload._delta
+            if (reversedDelta && reversedDelta.add) {
+                return new StandardExplicitParent(new StandardExplicitParentRemove(new StandardExplicitParentSimpleBase(reversedDelta.add)))
+            }
+            return undefined
+        }
+        const diffResult = this._payload.diff(incoming._payload)
+        if (diffResult) {
+            return new StandardExplicitParent(diffResult)
+        }
+        return undefined
+    }
+    mapContents(callback: (incoming: ComponentUUID) => ComponentUUID): StandardExplicitParent {
+        if (!this._payload) {
+            return this
+        }
+        if (this._payload instanceof StandardExplicitParentSimple) {
+            return new StandardExplicitParent(callback(this._payload.payload.data))
+        }
+        if (this._payload instanceof StandardExplicitParentRemove) {
+            return new StandardExplicitParent(new StandardExplicitParentRemove(new StandardExplicitParentSimpleBase(callback(this._payload.match.data))))
+        }
+        if (this._payload instanceof StandardExplicitParentReplace) {
+            return new StandardExplicitParent(new StandardExplicitParentReplace(
+                new StandardExplicitParentSimpleBase(callback(this._payload.match.data)),
+                new StandardExplicitParentSimpleBase(callback(this._payload.payload.data))
+            ))
+        }
+        throw new Error('Invalid StandardExplicitParent payload')
+    }
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `StandardExplicitParent` (with Simple/Remove/Replace variants) to model explicit parent values, including construction from schema/render tree, exact-match merge/diff rules, schema generation, and content mapping, with full tests and export.
> 
> - **Standardize: Explicit Parent**
>   - **New API**: `StandardExplicitParent` with variants `StandardExplicitParentSimple`, `StandardExplicitParentRemove`, `StandardExplicitParentReplace`, and base `StandardExplicitParentSimpleBase`.
>   - **Construction**: Accepts `ComponentUUID`, `Remove`/`Replace` structures, or WML schema/render tree; supports empty `Parent` (no value).
>   - **Operations**: `merge`, `diff` (exact-match semantics; throws `MergeConflictError` on mismatch), `mapContents`, `toJSON`.
>   - **Schema**: Generates `schema` and `nestedSchema` for `Parent`/`Remove`/`Replace` forms.
>   - **Exports**: Re-export from `standardize/explicit/index.ts`.
>   - **Tests**: Unit tests cover construction, merge/diff, mapping, schema generation, and error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5239d8d2e8c40a8be147163dab437626c3fe76d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->