### PR TITLE
Iss6553 asset lambda content header bugs

### DIFF
--- a/lambda/assets/contentHeaders/AGENT.md
+++ b/lambda/assets/contentHeaders/AGENT.md
@@ -2,16 +2,29 @@
 
 ## Overview
 
-The Content Headers data source provides filtered asset and component metadata for the content authoring UI, enabling content discovery and import workflows especially during the Bootstrapping phase. This data source aggregates asset information by zone and publishes real-time updates as assets are created, modified, or moved between zones.
+The Content Headers data source provides a **minimal, header-only projection** of asset components for the content authoring UI, enabling content discovery and import workflows especially during the Bootstrapping phase. This data source aggregates asset information by zone and publishes real-time updates as assets are created, modified, or moved between zones.
+
+## What is “Content Header” information?
+
+At a high level, **content header information is a stripped-down view of every component in an asset**, containing only the fields needed for navigation and identification in the Import Navigator:
+
+- **Per-component skeleton**:
+  - `tag`
+  - identifying keys: `key`, `universalKey`
+  - `shortName` (when present)
+- **No other component payload**: rich content, configuration, and children are intentionally omitted.
+- **Asset-level container**: these minimal components are wrapped in a `StandardForm` per asset, with a top-level `ReferenceList` pointing at each header component.
+
+This means the data source answers the question: **“What identifiable components exist in this asset, and what are their display names?”**, without exposing the full content of those components.
 
 ## Core Purpose
 
 The Content Headers data source serves as a specialized view of the assets system, providing:
 
 - **Zone-based Asset Discovery**: Organized view of assets across Canon, Library, and Personal zones
-- **Component Metadata**: Essential information (shortName, type) for Import Navigator display
-- **Real-time Updates**: Live synchronization with asset changes and zone movements
-- **Import Navigator Support**: Structured data format optimized for tabular UI display
+- **Component Header Metadata**: Minimal identification data (shortName, type, keys) for Import Navigator display
+- **Real-time Updates**: Live synchronization with asset changes and zone movements, expressed as header-only updates
+- **Import Navigator Support**: Structured data format optimized for tabular UI display and selection flows
 
 ## Technical Details
 

--- a/lambda/assets/contentHeaders/index.test.ts
+++ b/lambda/assets/contentHeaders/index.test.ts
@@ -40,15 +40,14 @@ jest.mock('../internalCache', () => ({
         get: jest.fn()
     }
 }))
-
-
-jest.mock('./extractHeader', () => ({
-    extractHeader: jest.fn()
-}))
+jest.mock('@tonylb/mtw-utilities/ts/uuid/index', () => {
+    return {
+        ...jest.requireActual('@tonylb/mtw-utilities/ts/uuid/___mocks___/index')
+    }
+})
 
 const assetDBMock = jest.mocked(assetDB, { shallow: false })
 const internalCacheMock = jest.mocked(internalCache, { shallow: false })
-const extractHeaderMock = jest.mocked(require('./extractHeader').extractHeader, { shallow: false })
 
 describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
     beforeEach(() => {
@@ -59,8 +58,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
         // Mock internal cache
         internalCacheMock.AssetData.get.mockResolvedValue([])
         internalCacheMock.AssetMetaData.get.mockResolvedValue([])
-        // Mock extractHeader
-        extractHeaderMock.mockReturnValue(undefined)
     })
 
     describe('Constructor', () => {
@@ -179,15 +176,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
                 standardForm: mockStandardForm
             }])
 
-            
-            // Mock extractHeader to return a component with header
-            const mockHeaderComponent = new StandardRoom({
-                tag: 'Room',
-                shortName: 'Test Room',
-                universalKey: 'ROOM#room1'
-            })
-            extractHeaderMock.mockReturnValue(mockHeaderComponent)
-
             const snapshot = await contentHeadersDataSource.snapshotContentGenerator?.('global')
 
             // First, verify the overall structure
@@ -217,7 +205,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             const canonWML = schemaToWML([canonAsset.standardForm.schema])
             expect(canonWML).toBe(deIndentWML(`
                 <Asset uuid=(test)>
-                    <Room uuid=(room1)><ShortName>Test Room</ShortName></Room>
+                    <Room uuid=(room1) key=(room1)><ShortName>Test Room</ShortName></Room>
                 </Asset>
             `))
 
@@ -225,7 +213,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             const libraryWML = schemaToWML([libraryAsset.standardForm.schema])
             expect(libraryWML).toBe(deIndentWML(`
                 <Asset uuid=(test)>
-                    <Room uuid=(room1)><ShortName>Test Room</ShortName></Room>
+                    <Room uuid=(room1) key=(room1)><ShortName>Test Room</ShortName></Room>
                 </Asset>
             `))
 
@@ -233,7 +221,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             const personalWML = schemaToWML([personalAsset.standardForm.schema])
             expect(personalWML).toBe(deIndentWML(`
                 <Asset uuid=(test)>
-                    <Room uuid=(room1)><ShortName>Test Room</ShortName></Room>
+                    <Room uuid=(room1) key=(room1)><ShortName>Test Room</ShortName></Room>
                 </Asset>
             `))
 
@@ -256,9 +244,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
 
         beforeEach(() => {
             mockStreamEvent = jest.fn()
-            
-            // Reset extractHeader mock
-            extractHeaderMock.mockReset()
         })
 
         describe('Component Updated Events', () => {
@@ -275,7 +260,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
                     shortName: 'Test Room',
                     universalKey: 'ROOM#room123'
                 })
-                extractHeaderMock.mockReturnValue(mockHeaderComponent)
 
                 const componentUpdatedEvent: SubscribedAssetsEvent = {
                     dataSourceKey: 'mtw.assets',
@@ -316,38 +300,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             it('should skip events when zone cannot be determined', async () => {
                 // Mock zone lookup failure
                 internalCacheMock.AssetMetaData.get.mockResolvedValue([])
-
-                const componentUpdatedEvent: SubscribedAssetsEvent = {
-                    dataSourceKey: 'mtw.assets',
-                    streamKey: 'ASSET#asset123',
-                    detailEnvelope: {
-                        type: 'Component Updated',
-                        component: new StandardRoom({
-                            tag: 'Room',
-                            shortName: 'Test Room',
-                            universalKey: 'ROOM#room123'
-                        })
-                    },
-                    timestamp: Date.now()
-                }
-
-                await contentHeadersDataSource.receiveEvents?.({
-                    events: [componentUpdatedEvent],
-                    streamEvent: mockStreamEvent
-                })
-
-                expect(mockStreamEvent).not.toHaveBeenCalled()
-            })
-
-            it('should skip events when component does not have header information', async () => {
-                // Mock zone lookup
-                internalCacheMock.AssetMetaData.get.mockResolvedValue([{
-                    AssetId: 'ASSET#asset123',
-                    zone: 'Canon'
-                }])
-
-                // Mock extractHeader to return undefined (no header)
-                extractHeaderMock.mockReturnValue(undefined)
 
                 const componentUpdatedEvent: SubscribedAssetsEvent = {
                     dataSourceKey: 'mtw.assets',
@@ -638,11 +590,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
             it('should handle mixed Zone Changed and Component Updated events', async () => {
                 // Mock zone lookup for component event
                 internalCacheMock.AssetMetaData.get.mockResolvedValue([{ AssetId: 'ASSET#test1', zone: 'Canon' }])
-                extractHeaderMock.mockReturnValue(new StandardRoom({
-                    tag: 'Room',
-                    shortName: 'Test Room',
-                    universalKey: 'ROOM#room123'
-                }))
 
                 const mixedEvents: SubscribedEvent[] = [
                     {
@@ -703,13 +650,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
                     .mockResolvedValueOnce([{ AssetId: 'ASSET#asset1', zone: 'Canon' }])
                     .mockResolvedValueOnce([{ AssetId: 'ASSET#asset2', zone: 'Library' }])
 
-                // Mock extractHeader
-                extractHeaderMock.mockReturnValue(new StandardRoom({
-                    tag: 'Room',
-                    shortName: 'Test Room',
-                    universalKey: 'ROOM#room123'
-                }))
-
                 const events: SubscribedAssetsEvent[] = [
                     {
                         dataSourceKey: 'mtw.assets',
@@ -729,11 +669,11 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
                         streamKey: 'ASSET#asset2',
                         detailEnvelope: {
                             type: 'Component Updated',
-                            component: new StandardRemove(new StandardRoom({
+                            component: new StandardRoom({
                                 tag: 'Room',
                                 shortName: 'Room 2',
                                 universalKey: 'ROOM#room2'
-                            }))
+                            })
                         },
                         timestamp: Date.now()
                     }
@@ -744,7 +684,7 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
                     streamEvent: mockStreamEvent
                 })
 
-                // Both Component Updated and StandardRemove events should generate content header updates
+                // Both Component Updated events should generate content header updates
                 expect(mockStreamEvent).toHaveBeenCalledTimes(2)
             })
         })
@@ -790,8 +730,6 @@ describe('ContentHeadersDataSource (mtw.assets.contentHeaders)', () => {
 
             it('should merge Asset Updated metadata with component header updates', async () => {
                 internalCacheMock.AssetMetaData.get.mockResolvedValue([{ AssetId: 'ASSET#mix', zone: 'Library' }])
-                // extractHeader returns a header component
-                extractHeaderMock.mockReturnValue(new StandardRoom({ tag: 'Room', shortName: 'Hdr', universalKey: 'ROOM#r1' }))
 
                 const events: SubscribedEvent[] = [
                     {

--- a/lambda/assets/contentHeaders/index.ts
+++ b/lambda/assets/contentHeaders/index.ts
@@ -84,6 +84,25 @@ const isSubscribedEvent = (event: StreamingEventPayload): event is SubscribedEve
     return isSubscribedAssetsEvent(event) || isSubscribedWMLEvent(event)
 }
 
+//
+// Helper to project a full component down to its "header" representation:
+// tag, keys, and shortName (if present), with all other payload stripped.
+//
+function extractHeaderComponent(component: any) {
+    if (!component) {
+        return undefined
+    }
+
+    const minimalJson = {
+        tag: component.tag as any,
+        key: component.key,
+        universalKey: component.universalKey,
+        shortName: hasShortName(component) ? component.shortName?.toJSON() : undefined
+    } as any
+
+    return standardComponentFactory(minimalJson) ?? undefined
+}
+
 const generateContentHeadersSnapshot = async (): Promise<ContentHeadersSnapshot> => {
     try {
         // Query all assets from the DynamoDB table using DataCategoryIndex
@@ -106,20 +125,28 @@ const generateContentHeadersSnapshot = async (): Promise<ContentHeadersSnapshot>
                 if (!assetCache?.standardForm) {
                     return undefined
                 }
-                
-                // Transform the asset's StandardForm to contain only header information for all components
+
+                // Start from a clone so we preserve asset-level metadata (e.g., ShortName)
                 const headersAsset = assetCache.standardForm._clone()
-                headersAsset._components = headersAsset._components
+
+                // Project each component down to its header representation
+                const headerComponents = (headersAsset._components ?? [])
                     .filter(excludeUndefined)
-                
-                if (headersAsset._components.length > 0) {
-                    return {
-                        assetId,
-                        zone,
-                        standardForm: headersAsset
-                    }
+                    .map((component) => extractHeaderComponent(component))
+                    .filter(excludeUndefined)
+
+                if (headerComponents.length === 0) {
+                    return undefined
                 }
-                return undefined
+
+                headersAsset._components = headerComponents
+                headersAsset._topLevel = new ReferenceList(headerComponents.map((component) => (component.referenceData)))
+
+                return {
+                    assetId,
+                    zone,
+                    standardForm: headersAsset
+                }
             })
         ).then(results => results.filter(excludeUndefined))
         
@@ -274,16 +301,9 @@ function createAggregatedContentHeadersUpdate(
                     console.warn(`Component Updated event for asset ${assetId} missing component data, skipping`)
                     continue
                 }
-                
-                const minimalJson = {
-                    tag: component.tag as any,
-                    key: component.key,
-                    universalKey: component.universalKey,
-                    shortName: hasShortName(component) ? component.shortName?.toJSON() : undefined
-                } as any
-            
-                const headerComponent = standardComponentFactory(minimalJson)
-                if (headerComponent) {   
+
+                const headerComponent = extractHeaderComponent(component)
+                if (headerComponent) {
                     headerComponents.push(headerComponent)
                 }
             } else if (event.detailEnvelope.type === 'Asset Updated') {

--- a/lambda/assets/contentHeaders/index.ts
+++ b/lambda/assets/contentHeaders/index.ts
@@ -16,9 +16,12 @@ import { AssetUUID } from '@tonylb/mtw-base/ts/schema'
 import { assetDB } from '@tonylb/mtw-utilities/ts/dynamoDB'
 import internalCache from '../internalCache'
 import { excludeUndefined } from '@tonylb/mtw-utilities/ts/lists'
-import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'
+import { hasShortName, StandardForm } from '@tonylb/mtw-wml/ts/standardize'
 import { WMLZoneEvent, isWMLZoneEvent } from '@tonylb/mtw-interfaces/ts/eventBridge/wml'
 import { Zone } from '@tonylb/mtw-asset-workspace'
+import { standardComponentFactory } from '@tonylb/mtw-wml/ts/standardize/componentFactory'
+import { defaultComponentFromTag } from '@tonylb/mtw-wml/ts/standardize/baseClasses'
+import { ReferenceList } from '@tonylb/mtw-wml/ts/standardize/components/reference'
 
 //
 // Replayable DataSource singleton for mtw.assets.contentHeaders
@@ -258,7 +261,6 @@ function createAggregatedContentHeadersUpdate(
     events: SubscribedEvent[]
 ): ContentHeadersUpdate | null {
     try {
-        const assetKey = assetId.split('#')[1]
         const headerComponents: any[] = []
         let metadataAsset: StandardForm | null = null
         
@@ -273,7 +275,17 @@ function createAggregatedContentHeadersUpdate(
                     continue
                 }
                 
-                headerComponents.push(component)
+                const minimalJson = {
+                    tag: component.tag as any,
+                    key: component.key,
+                    universalKey: component.universalKey,
+                    shortName: hasShortName(component) ? component.shortName?.toJSON() : undefined
+                } as any
+            
+                const headerComponent = standardComponentFactory(minimalJson)
+                if (headerComponent) {   
+                    headerComponents.push(headerComponent)
+                }
             } else if (event.detailEnvelope.type === 'Asset Updated') {
                 const assetUpdated = event.detailEnvelope as AssetUpdatedEventUpdate
                 // Consume the provided StandardForm directly
@@ -289,6 +301,7 @@ function createAggregatedContentHeadersUpdate(
         // Build a StandardForm from header metadata, then assign component instances
         const standardForm = metadataAsset ? metadataAsset._clone() : new StandardForm(assetId)
         standardForm._components = headerComponents
+        standardForm._topLevel = new ReferenceList(headerComponents.map((component) => (component.referenceData)))
         
         return {
             type: 'Headers Updated',

--- a/lambda/assets/fetchImportDefaults/index.test.ts
+++ b/lambda/assets/fetchImportDefaults/index.test.ts
@@ -7,6 +7,11 @@ import internalCache from '../internalCache'
 jest.mock('../messageBus')
 import messageBus from '../messageBus'
 jest.mock('./baseClasses')
+jest.mock('@tonylb/mtw-utilities/ts/uuid/index', () => {
+    return {
+        ...jest.requireActual('@tonylb/mtw-utilities/ts/uuid/___mocks___/index')
+    }
+})
 import { Graph } from '@tonylb/mtw-utilities/ts/graphStorage/utils/graph'
 import { FetchImportsJSONHelper } from './baseClasses'
 import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks the content headers data source to emit minimal header-only components, aggregates per-asset updates, and updates tests/docs accordingly.
> 
> - **Content Headers Data Source**:
>   - Implement header-only projection via `extractHeaderComponent`, cloning `StandardForm`, setting `_components` to minimal components, and populating `_topLevel` with `ReferenceList`.
>   - Aggregate per-asset events to build `Headers Updated` (merging `Asset Updated` metadata with `Component Updated` headers) and stream `Zone Updated` for WML zone changes.
>   - Snapshot generator queries assets, constructs header-only `standardForm` per asset, and skips assets without headerable components.
> - **Tests**:
>   - Update `contentHeaders` tests to validate header-only WML (including `key`), aggregated update behavior, zone handling, and that `StandardRemove` does not emit updates.
>   - Add UUID jest mock usage.
> - **Docs**:
>   - Revise `AGENT.md` to define the header-only model, event types, data format, and usage.
> - **Fetch Import Defaults**:
>   - Extend tests with richer fixtures and assert SNS message uses `Targets` attributes; add UUID mock.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8c08ff10da1ad9c6dd612e29c1e05ee6e5310c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->