### PR TITLE
ISS6556: Deprecated unwrapStandardComponent helper function

### DIFF
--- a/packages/mtw-wml/ts/standardize/baseClasses.ts
+++ b/packages/mtw-wml/ts/standardize/baseClasses.ts
@@ -48,18 +48,6 @@ export type StandardReplace = {
     implicitParent?: StandardKeyData;  // Parent StandardKey (serialized as StandardKeyData, minimal identifier without tag)
 }
 
-export const unwrapStandardComponent = (component: StandardComponentData): StandardComponentNonEditData => {
-    if (isStandardNonEdit(component)) {
-        return component
-    }
-    else if (isStandardRemove(component)) {
-        return component.component
-    }
-    else {
-        return component.payload
-    }
-}
-
 export type StandardComponentData = StandardComponentNonEditData | StandardRemove | StandardReplace
 export type StandardComponentTag = StandardComponentData["tag"]
 

--- a/packages/mtw-wml/ts/standardize/components/dataTypes/index.ts
+++ b/packages/mtw-wml/ts/standardize/components/dataTypes/index.ts
@@ -90,18 +90,6 @@ export const isStandardReplaceWithOptions = (options: { typeGuard?: (value: any)
 
 export const isStandardReplace = isStandardReplaceWithOptions()
 
-export const unwrapStandardComponent = (component: StandardComponentData): StandardComponentNonEditData => {
-    if (isStandardNonEdit(component)) {
-        return component
-    }
-    else if (isStandardRemove(component)) {
-        return component.component
-    }
-    else {
-        return component.payload
-    }
-}
-
 export type StandardFormData = {
     universalKey: AssetUUID;
     components: StandardComponentData[];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes deprecated `unwrapStandardComponent` helper from standardization modules.
> 
> - **Cleanup**:
>   - Remove `unwrapStandardComponent` from:
>     - `packages/mtw-wml/ts/standardize/baseClasses.ts`
>     - `packages/mtw-wml/ts/standardize/components/dataTypes/index.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b362b2ebd8c152b7221fe16c05accde7cd1ac803. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->