### PR TITLE
ISS6557: Renamed isStandardComponentData typeguard

### DIFF
--- a/packages/mtw-wml/ts/standardize/baseClasses.ts
+++ b/packages/mtw-wml/ts/standardize/baseClasses.ts
@@ -61,14 +61,10 @@ export const isStandardMap = isStandardFactory<StandardMapData>("Map")
 export const isStandardMessage = isStandardFactory<StandardMessageData>("Message")
 export const isStandardMoment = isStandardFactory<StandardMomentData>("Moment")
 
-
-
 export const isStandardImage = isStandardFactory<StandardImageData>("Image")
 
 export const isStandardRemove = isStandardFactory<StandardRemove>("Remove")
 export const isStandardReplace = isStandardFactory<StandardReplace>("Replace")
-
-export const isStandardNonEdit = (value: StandardComponentData): value is Exclude<StandardComponentData, StandardRemove | StandardReplace> => (!(["Remove", "Replace"].includes(value.tag)))
 
 export const defaultComponentFromTag = (tag: SchemaTag["tag"], key?: string, universalKey?: ComponentUUID): Exclude<StandardComponentNonEditData, string> => {
     switch(tag) {

--- a/packages/mtw-wml/ts/standardize/components/dataTypes/index.ts
+++ b/packages/mtw-wml/ts/standardize/components/dataTypes/index.ts
@@ -53,7 +53,7 @@ export type StandardReplaceData = {
 
 export const isStandardFactory = <T extends StandardComponentData>(tag: StandardComponentTag) => (value: StandardComponentData): value is T => (typeof value !== 'string' && value.tag === tag)
 
-export const isStandardNonEdit = (value: any): value is StandardComponentNonEditData => (
+export const isStandardComponentData = (value: any): value is StandardComponentData => (
     isStandardCharacter(value) ||
     isStandardExample(value) ||
     isStandardRoom(value) ||
@@ -71,7 +71,7 @@ export const isStandardRemoveWithOptions = (options: { typeGuard?: (value: any) 
     }
     return checkAll(
         ('tag' in arg && arg.tag === 'Remove'),
-        ('component' in arg && (options.typeGuard ?? isStandardNonEdit)(arg.component))
+        ('component' in arg && (options.typeGuard ?? isStandardComponentData)(arg.component))
     )
 }
 
@@ -83,8 +83,8 @@ export const isStandardReplaceWithOptions = (options: { typeGuard?: (value: any)
     }
     return checkAll(
         ('tag' in arg && arg.tag === 'Replace'),
-        ('match' in arg && (options.typeGuard ?? isStandardNonEdit)(arg.match)),
-        ('payload' in arg && (options.typeGuard ?? isStandardNonEdit)(arg.payload))
+        ('match' in arg && (options.typeGuard ?? isStandardComponentData)(arg.match)),
+        ('payload' in arg && (options.typeGuard ?? isStandardComponentData)(arg.payload))
     )
 }
 
@@ -98,8 +98,6 @@ export type StandardFormData = {
     summary?: StandardEditableData<RenderTree>;
     topLevel?: ReferenceListData;
 }
-
-export const isStandardComponentData = (arg: any): arg is StandardComponentData => (isStandardNonEdit(arg) || isStandardRemove(arg) || isStandardReplace(arg))
 
 export const isStandardForm = (arg: any): arg is StandardFormData => {
     if (typeof arg !== 'object') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames the non-edit component type guard to isStandardComponentData and updates Remove/Replace validators and NDJSON/form checks to use it.
> 
> - **Type Guards**:
>   - Rename `isStandardNonEdit` to `isStandardComponentData` in `components/dataTypes/index.ts`.
>   - Update `isStandardRemoveWithOptions` and `isStandardReplaceWithOptions` to use `isStandardComponentData` for `component`, `match`, and `payload`.
>   - Update `isStandardForm` components validation to use `isStandardComponentData`.
> - **NDJSON Validation**:
>   - In `standardize/baseClasses.ts`, use `isStandardComponentData` for component-line validation; remove obsolete `isStandardNonEdit` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0ae2c5d59bf49ccc43dadcb3bced7d077aef6fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->