### PR TITLE
ISS6560: Deprecated standardComponentByTag helper function

### DIFF
--- a/charcoal-client/AGENT.md
+++ b/charcoal-client/AGENT.md
@@ -231,7 +231,7 @@ updateStandard({ type: 'update', update: (draft) => {
 }})
 
 // 4. Add components (rooms, features, etc.)
-const component = standardComponentByTag('Room', 'Room1')
+const component = standardComponentFactory({ tag: 'Room', key: 'Room1' })
 draft._components = [...draft._components, component]
 ```
 

--- a/charcoal-client/src/components/Library/Edit/EditAsset.tsx
+++ b/charcoal-client/src/components/Library/Edit/EditAsset.tsx
@@ -49,7 +49,6 @@ import StandardFeature from '@tonylb/mtw-wml/ts/standardize/components/feature'
 import StandardKnowledge from '@tonylb/mtw-wml/ts/standardize/components/knowledge'
 import StandardMap from '@tonylb/mtw-wml/ts/standardize/components/map'
 import StandardImage from '@tonylb/mtw-wml/ts/standardize/components/image'
-import { standardComponentByTag } from '@tonylb/mtw-wml/ts/standardize/nonEditFactory'
 import { RecentlyVisited } from './RecentlyVisited'
 import { LabelledIndentBox } from './LabelledIndentBox'
 import { blue } from '@mui/material/colors'
@@ -60,6 +59,7 @@ import { StandardLiteral } from '@tonylb/mtw-wml/ts/standardize/literal'
 import { StandardRender } from '@tonylb/mtw-wml/ts/standardize/render'
 import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'
 import { useDebouncedOnChange } from '../../../hooks/useDebounce'
+import { standardComponentFactory } from '@tonylb/mtw-wml/ts/standardize/componentFactory'
 
 type AssetEditFormProps = {}
 
@@ -167,7 +167,7 @@ const AssetEditForm: FunctionComponent<AssetEditFormProps> = () => {
                 let nextIndex = 1
                 while (`${tag}${nextIndex}` in draft.byId) { nextIndex++ }
                 const defaultedKey = `${tag}${nextIndex}`
-                const component = standardComponentByTag(tag, defaultedKey)
+                const component = standardComponentFactory({ tag, key: defaultedKey })
                 if (component) {
                     draft._components = [...draft._components, component]
                 }

--- a/charcoal-client/src/slices/personalAssets/index.ts
+++ b/charcoal-client/src/slices/personalAssets/index.ts
@@ -24,7 +24,6 @@ import {
     UpdateStandardPayload
 } from './reducers'
 import { EphemeraAssetId, EphemeraCharacterId } from '@tonylb/mtw-interfaces/ts/baseClasses'
-import { getPlayer } from '../player'
 import { PromiseCache } from '../promiseCache'
 import { heartbeat } from '../stateSeekingMachine/ssmHeartbeat'
 import { socketDispatchPromise } from '../lifeLine'
@@ -32,17 +31,16 @@ import { isStandardRoom } from '@tonylb/mtw-wml/ts/standardize/baseClasses'
 import { treeNodeTypeguard } from '@tonylb/mtw-base/ts/genericTree'
 import { SubscriptionClientMessage } from '@tonylb/mtw-interfaces/ts/subscriptions'
 import { push } from '../UI/feedback'
-import { excludeUndefined } from '../../lib/lists'
 import { schemaToWML } from '@tonylb/mtw-wml/ts/schema'
 import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'
 import Debounce from '../../lib/keyedDebounce'
 import { isSchemaImport, SchemaImportMapping } from '@tonylb/mtw-base/ts/schema/metaData'
-import { standardComponentByTag } from '@tonylb/mtw-wml/ts/standardize/nonEditFactory'
 import StandardRoom from '@tonylb/mtw-wml/ts/standardize/components/room'
 import { StandardRender } from '@tonylb/mtw-wml/ts/standardize/render'
 import { deepEqual } from '../../lib/objects'
 import StandardExample from '@tonylb/mtw-wml/ts/standardize/components/example'
 import { AssetUUID, ComponentUUID, isSchemaComponentUUID, isSchemaAssetUUID } from '@tonylb/mtw-base/ts/schema'
+import { standardComponentFactory } from '@tonylb/mtw-wml/ts/standardize/componentFactory'
 
 const autoSaveDebounce = new Debounce()
 
@@ -292,7 +290,7 @@ export const addImport = ({ assetId, fromAsset, uuid, tag }: {
                 draft.byUniversalId[uuid] = newComponent.withImport(fromAsset)
             }
             else {
-                const component = standardComponentByTag(tag, uuid)
+                const component = standardComponentFactory({ tag, universalKey: uuid })
                 if (!component) {
                     throw new Error(`Could not create component for tag ${tag}`)
                 }

--- a/packages/mtw-wml/ts/standardize/nonEditFactory.ts
+++ b/packages/mtw-wml/ts/standardize/nonEditFactory.ts
@@ -54,33 +54,4 @@ export const standardNonEditComponentFactory = (arg: StandardComponentData | Gen
     return undefined
 }
 
-//
-// standardComponentByTag takes an incoming tag and key, and creates the appropriate StandardComponent
-//
-export const standardComponentByTag = (tag: ComponentTag, key: string): StandardComponent | undefined => {
-    switch (tag) {
-        case "Character":
-            return new StandardCharacter(key)
-        case "Example":
-            return new StandardExample(key)
-        case "Room":
-            return new StandardRoom(key)
-        case "Feature":
-            return new StandardFeature(key)
-        case "Knowledge":
-            return new StandardKnowledge(key)
-        case "Map":
-            return new StandardMap(key)
-        case "Message":
-            return new StandardMessage(key)
-        case "Moment":
-            return new StandardMoment(key)
-        case "Image":
-            return new StandardImage(key)
-        default:
-            return undefined
-    }
-
-}
-
 export default standardNonEditComponentFactory


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces uses of standardComponentByTag with standardComponentFactory across client code and docs, and removes the old helper.
> 
> - **Client (Library/Edit)**
>   - Switch `EditAsset.tsx` to create components via `standardComponentFactory({ tag, key })`.
> - **Client (Personal Assets)**
>   - Update `addImport` to create/import components using `standardComponentFactory({ tag, universalKey })`.
> - **WML Package**
>   - Remove deprecated `standardComponentByTag` from `ts/standardize/nonEditFactory.ts`.
> - **Docs**
>   - Update `AGENT.md` example to use `standardComponentFactory`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a0d4310c0230f8fa7b790fd6dcd542406fd7bfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->