### PR TITLE
ISS6798: Remedied a MarkFacet inconsistency in replace payloads

### DIFF
--- a/packages/mtw-wml/ts/standardize/keys/facets/mark.ts
+++ b/packages/mtw-wml/ts/standardize/keys/facets/mark.ts
@@ -270,8 +270,9 @@ export class MarkFacetReplaceClass extends ReplaceClass {
     }
 
     renderFacet(reference: StandardReference, payload: MarkFacetPayloadType, referenceRender?: GenericTreeNode<SchemaTag>): { newNode?: GenericTreeNode<SchemaTag>, aggregatedNode?: GenericTreeNode<SchemaTag> } {
-        // Use schema getter which already returns Replace-wrapped structure
-        const replaceSchema = this.schema[0];
+        // Use nestedSchema to get the wrapped structure (Replace > ReplaceMatch/ReplacePayload > Match > String)
+        const nested = this.nestedSchema({ tag: 'Match' as const });
+        const replaceSchema = nested[0];
 
         if (referenceRender && treeNodeTypeguard(isSchemaRemove)(referenceRender)) {
             return { aggregatedNode: referenceRender };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes how `MarkFacetReplaceClass.renderFacet` constructs the Replace node.
> 
> - Now uses `nestedSchema` to build `Replace > (ReplaceMatch|ReplacePayload) > Match > String` correctly instead of directly accessing `schema[0]`
> - Ensures consistent wrapping of replace payloads during Mark facet rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93eca605050dad676bb5903d39d44d092997176b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->