### PR TITLE
Iss6743 position facet migration

### DIFF
--- a/charcoal-client/src/components/Maps/Controller/addRoom.ts
+++ b/charcoal-client/src/components/Maps/Controller/addRoom.ts
@@ -1,7 +1,7 @@
 import { UpdateStandardPayload } from "../../../slices/personalAssets/reducers"
 import StandardRoom from "@tonylb/mtw-wml/ts/standardize/components/room"
 import { StandardForm } from "@tonylb/mtw-wml/ts/standardize"
-import StandardPosition from "@tonylb/mtw-wml/ts/standardize/components/position"
+import { StandardPositionFacet } from "@tonylb/mtw-wml/ts/standardize/keys/facets/position"
 import StandardMap from "@tonylb/mtw-wml/ts/standardize/components/map"
 import { v4 as uuidv4 } from 'uuid'
 import { enforceTypedKey } from '@tonylb/mtw-utilities/ts/types'
@@ -31,11 +31,11 @@ export const addRoomFactory = ({
             })
             const mapComponent = returnValue.byUniversalId[mapId]
             if (mapComponent && mapComponent instanceof StandardMap) {
-                mapComponent.positions.push(new StandardPosition({
-                    room: defaultedRoomId,
-                    x: x ?? 0,
-                    y: y ?? 0
-                }))
+                const newFacet = new StandardPositionFacet({
+                    reference: { universalKey: defaultedRoomId, tag: 'Room' },
+                    payload: { x: x ?? 0, y: y ?? 0 }
+                })
+                mapComponent.positions.items.push(newFacet)
             }
             return returnValue
         }

--- a/charcoal-client/src/components/Maps/Controller/index.tsx
+++ b/charcoal-client/src/components/Maps/Controller/index.tsx
@@ -17,9 +17,9 @@ import { isSchemaComponentUUID } from "@tonylb/mtw-base/ts/schema"
 
 import { StandardKey } from "@tonylb/mtw-wml/ts/standardize/components/reference"
 import { excludeUndefined } from "../../../lib/lists"
-import StandardPosition, { StandardPositionSimple, StandardPositionSimpleBase } from "@tonylb/mtw-wml/ts/standardize/components/position"
+import StandardPosition, { StandardPositionSimple } from "@tonylb/mtw-wml/ts/standardize/components/position"
+import { StandardPositionFacet, PositionRemoveClass } from "@tonylb/mtw-wml/ts/standardize/keys/facets/position"
 import { StandardExitPlain } from "@tonylb/mtw-wml/ts/standardize/components/exit"
-import { extractExitsFromStandardForm } from "../exitExtraction"
 
 export const MapContext = React.createContext<MapContextType>({
     mapId: 'MAP#default',
@@ -82,16 +82,35 @@ const localPositionsFromStandardForms = ({ inherited, local, mapId }: { inherite
     const localPositionsFromSingleStandardForm = (standardForm: StandardForm): MapContextPosition[] => {
         const mapComponent = standardForm.byUniversalId[mapId]
         if (mapComponent && mapComponent instanceof StandardMap) {
-            return mapComponent.positions.map((position) => {
-                const roomUniversalKey = position.room.universalKey
+            return mapComponent.positions.items.map((facet) => {
+                const roomUniversalKey = facet.reference.universalKey
                 if (!roomUniversalKey) {
                     return undefined
                 }
                 const roomComponent = standardForm.byUniversalId[roomUniversalKey]
                 if (roomComponent && roomComponent instanceof StandardRoom) {
+                    // Skip Remove operations - they don't represent visible positions
+                    if (facet.payload instanceof PositionRemoveClass) {
+                        return undefined
+                    }
+                    
+                    // Use .plain pattern to access the underlying payload base
+                    // For Plain: .plain returns StandardPositionPayloadBase
+                    // For Replace: .plain returns the payload (new value) StandardPositionPayloadBase
+                    // For Remove: .plain returns the match, but we skip those above
+                    const plainPayload = facet.payload.plain
+                    if (!plainPayload) {
+                        return undefined
+                    }
+                    
+                    const position = new StandardPosition(new StandardPositionSimple({ 
+                        room: roomUniversalKey, 
+                        x: plainPayload.x, 
+                        y: plainPayload.y 
+                    }))
                     return {
-                        name: roomComponent.shortName?._payload.plain.toJSON() ?? '',
-                        position: position.clone()
+                        name: roomComponent.shortName?._payload?.plain?.toJSON() ?? '',
+                        position
                     }
                 }
                 return undefined
@@ -138,7 +157,7 @@ export const MapController: FunctionComponent<{ mapId: `MAP#${string}`; children
             const roomComponent = editable.byUniversalId[id]
             if (roomComponent && roomComponent instanceof StandardRoom) {
                 return {
-                    name: roomComponent.shortName?._payload.plain.toJSON() ?? '',
+                    name: roomComponent.shortName?._payload?.plain?.toJSON() ?? '',
                     position: new StandardPosition(new StandardPositionSimple({ room: id, x, y }))
                 }
             }
@@ -157,11 +176,14 @@ export const MapController: FunctionComponent<{ mapId: `MAP#${string}`; children
             const mapComponent = draft.byUniversalId[mapId]
             if (mapComponent && mapComponent instanceof StandardMap) {
                 nodes.forEach(({ id, x, y }) => {
-                    const position = mapComponent.positions.find((position) => (position.room.universalKey === id))
-                    const payload = position?._payload
-                    if (payload && payload instanceof StandardPositionSimpleBase) {
-                        payload.x = x
-                        payload.y = y
+                    const facetIndex = mapComponent.positions.items.findIndex((facet) => facet.reference.universalKey === id)
+                    if (facetIndex !== -1) {
+                        const facet = mapComponent.positions.items[facetIndex]
+                        const updatedFacet = new StandardPositionFacet({
+                            reference: facet.reference.toJSON(),
+                            payload: { x, y }
+                        })
+                        mapComponent.positions.items[facetIndex] = updatedFacet
                     }
                 })
             }
@@ -273,7 +295,7 @@ export const MapDisplayController: FunctionComponent<{ standardForm: StandardFor
             const roomComponent = standardForm.byUniversalId[id]
             if (roomComponent && roomComponent instanceof StandardRoom) {
                 return {
-                    name: roomComponent.shortName?._payload.plain.toJSON() ?? '',
+                    name: roomComponent.shortName?._payload?.plain?.toJSON() ?? '',
                     position: new StandardPosition(new StandardPositionSimple({ room: id, x, y }))
                 }
             }

--- a/charcoal-client/src/components/Maps/Edit/MapDThree/MapDThreeTree.ts
+++ b/charcoal-client/src/components/Maps/Edit/MapDThree/MapDThreeTree.ts
@@ -40,10 +40,10 @@ export const mapTranslate = ({
         throw new Error(`Map ${mapId} is not a StandardMap`)
     }
     
-    const nodes: MapNodes = map.positions.map((position) => ({
-            id: position._payload.plain.room.universalKey,
-            x: position._payload.plain.x,
-            y: position._payload.plain.y,
+    const nodes: MapNodes = map.positions.items.map((facet) => ({
+            id: facet.reference.universalKey,
+            x: facet.payload.plain?.x,
+            y: facet.payload.plain?.y,
         }))
         .filter((node): node is SimNode => (Boolean(node.id && isSchemaComponentUUID(node.id) && node.id.startsWith('ROOM#'))))
     

--- a/charcoal-client/src/components/Maps/Edit/MapLayers/index.tsx
+++ b/charcoal-client/src/components/Maps/Edit/MapLayers/index.tsx
@@ -204,16 +204,16 @@ export const MapLayers: FunctionComponent<MapLayersProps> = ({ mapId }) => {
         // 2. Rooms in the combined map, with local exits that connect to positioned rooms
         
         // Get rooms with local positions
-        const positionedRooms = unique(localMapComponent.positions
-            .map((position) => position.room.universalKey)
+        const positionedRooms = unique(localMapComponent.positions.items
+            .map((facet) => facet.reference.universalKey)
             .filter((roomId): roomId is `ROOM#${string}` => 
                 Boolean(roomId && roomId.startsWith('ROOM#'))
             )
         )
         
         // Get rooms that have local exits connecting to positioned rooms
-        const allPositionedRooms = mapComponent.positions
-            .map((position) => position.room.universalKey!)
+        const allPositionedRooms = mapComponent.positions.items
+            .map((facet) => facet.reference.universalKey!)
             .filter(excludeUndefined)
             .map((roomId) => standardForm.byUniversalId[roomId as ComponentUUID])
             .filter(excludeUndefined)
@@ -231,8 +231,8 @@ export const MapLayers: FunctionComponent<MapLayersProps> = ({ mapId }) => {
         // Helper function to get relevant exits from a room
         const getRelevantExits = (room: StandardRoom): StandardExit[] => {
             return room.exits.filter((exit) => {
-                const destinationId = exit.payload?.to.universalKey
-                const destinationKey = destinationId.universalKey
+                const destinationId = exit.plain?.to.universalKey
+                const destinationKey = destinationId
                 return destinationKey && allPositionedRoomIds.includes(destinationKey as `ROOM#${string}`)
             })
         }
@@ -255,11 +255,11 @@ export const MapLayers: FunctionComponent<MapLayersProps> = ({ mapId }) => {
             }
             
             const roomKey = roomComponent.key
-            const roomName = roomComponent.shortName?._payload.plain.toJSON() ?? roomKey ?? 'Room'
+            const roomName = roomComponent.shortName?._payload?.plain?.toJSON() ?? roomKey ?? 'Room'
             
             // Check if this room has a position in the local map
-            const position = localMapComponent.positions.find((pos) => 
-                pos.room.universalKey === roomId
+            const positionFacet = localMapComponent.positions.items.find((facet) => 
+                facet.reference.universalKey === roomId
             )
             
             return (
@@ -270,15 +270,19 @@ export const MapLayers: FunctionComponent<MapLayersProps> = ({ mapId }) => {
                     newestRoom={false}
                 >
                     {/* Position information if available */}
-                    {position && (
-                        <PositionLayer x={position.x} y={position.y} />
+                    {positionFacet?.payload.plain && (
+                        <PositionLayer x={positionFacet.payload.plain.x} y={positionFacet.payload.plain.y} />
                     )}
                     
                     {/* Exits from this room */}
-                    {getRelevantExits(roomComponent).map((exit, index) => {                        
-                        const destinationComponent = standardForm._lookup(exit._payload.plain.to.toJSON())
+                    {getRelevantExits(roomComponent).map((exit, index) => {
+                        const destinationKey = exit.plain?.to.toJSON()
+                        if (!destinationKey) {
+                            return null
+                        }
+                        const destinationComponent = standardForm._lookup(destinationKey)
                         const exitName = (destinationComponent && destinationComponent instanceof StandardRoom) 
-                            ? destinationComponent.shortName?._payload.plain.toJSON() ?? destinationComponent.key ?? ''
+                            ? destinationComponent.shortName?._payload?.plain?.toJSON() ?? destinationComponent.key ?? ''
                             : ''
                         
                         return (

--- a/charcoal-client/src/components/Maps/exitExtraction.ts
+++ b/charcoal-client/src/components/Maps/exitExtraction.ts
@@ -23,14 +23,14 @@ export const extractExitsFromStandardForm = (
 
     // Create a set of room IDs that have positions in the map for fast lookup
     const positionedRoomIds = new Set(
-        mapComponent.positions
-            .map(position => position.room.universalKey)
+        mapComponent.positions.items
+            .map(facet => facet.reference.universalKey)
             .filter((roomId): roomId is ComponentUUID => roomId !== undefined)
     )
 
     // Extract all exits from all rooms in the map
-    return mapComponent.positions
-        .map(position => position.room.universalKey)
+    return mapComponent.positions.items
+        .map(facet => facet.reference.universalKey)
         .filter((roomId): roomId is ComponentUUID => roomId !== undefined)
         .map(roomId => standardForm.byUniversalId[roomId])
         .filter((roomComponent): roomComponent is StandardRoom => 

--- a/lambda/ephemera/internalCache/componentRender.ts
+++ b/lambda/ephemera/internalCache/componentRender.ts
@@ -268,8 +268,8 @@ export class ComponentRenderData {
             //
             // Figure out how to properly map room keys to EphemeraId during extraction phases above
             //
-            const roomMetaPromise = Promise.all((merged?.positions ?? []).map(async (position) => {
-                const ephemeraId = position.room.universalKey as EphemeraRoomId
+            const roomMetaPromise = Promise.all((merged?.positions.items ?? []).map(async (facet) => {
+                const ephemeraId = facet.reference.universalKey as EphemeraRoomId
                 const metaByAsset = await this._componentMeta(ephemeraId, unique(globalAssets || [], characterAssets) as AssetUUID[])
                 const roomMeta = allAssets
                     .map((assetId) => (metaByAsset[assetId] ? [metaByAsset[assetId]] : []))
@@ -283,11 +283,11 @@ export class ComponentRenderData {
                         .filter(excludeUndefined)
                         .filter((exit) => (Boolean(
                             merged &&
-                            merged.positions.find((position) => (position.room.standardKey.equals(exit.to)))
+                            merged.positions.items.find((facet) => (facet.reference.standardKey.equals(exit.to)))
                         )))
                         .map((exit) => ({ description: exit.description?._payload?.plain?.toJSON?.() ?? '' as string, to: exit.to.toJSON() as EphemeraRoomId })),
-                    x: position.x,
-                    y: position.y
+                    x: facet.payload.plain?.x,
+                    y: facet.payload.plain?.y
                 }
             }))
             const [rooms, fileURLs, rest] = await Promise.all([
@@ -299,11 +299,7 @@ export class ComponentRenderData {
                 tag: 'Map',
                 universalKey: EphemeraId,
                 images: [],
-                positions: merged?.positions?.map((position) => ({
-                    x: position.x,
-                    y: position.y,
-                    room: position.room.universalKey as EphemeraRoomId
-                })) ?? [],
+                positions: merged?.positions?.toJSON() ?? [],
                 ...rest
             }
             return new StandardForm([

--- a/packages/mtw-wml/ts/__snapshots__/dungeon.test.ts.snap
+++ b/packages/mtw-wml/ts/__snapshots__/dungeon.test.ts.snap
@@ -765,36 +765,48 @@ exports[`large WML test should standardize properly 1`] = `
     "name": undefined,
     "positions": [
       {
-        "room": {
+        "payload": {
+          "x": 0,
+          "y": 250,
+        },
+        "reference": {
           "key": "VORTEX",
+          "tag": "Room",
           "universalKey": undefined,
         },
-        "x": 0,
-        "y": 250,
       },
       {
-        "room": {
+        "payload": {
+          "x": 0,
+          "y": 150,
+        },
+        "reference": {
           "key": "cave",
+          "tag": "Room",
           "universalKey": undefined,
         },
-        "x": 0,
-        "y": 150,
       },
       {
-        "room": {
+        "payload": {
+          "x": -150,
+          "y": 100,
+        },
+        "reference": {
           "key": "curvingPassage",
+          "tag": "Room",
           "universalKey": undefined,
         },
-        "x": -150,
-        "y": 100,
       },
       {
-        "room": {
+        "payload": {
+          "x": -150,
+          "y": 0,
+        },
+        "reference": {
           "key": "chamber",
+          "tag": "Room",
           "universalKey": undefined,
         },
-        "x": -150,
-        "y": 0,
       },
     ],
     "tag": "Map",

--- a/packages/mtw-wml/ts/standardize/components/dataTypes/map.ts
+++ b/packages/mtw-wml/ts/standardize/components/dataTypes/map.ts
@@ -2,15 +2,15 @@ import { GenericTree } from "@tonylb/mtw-base/ts/genericTree";
 import { StandardBaseData } from "./abstract"
 import { checkAll, checkTypes } from "./typeguards";
 import { SchemaTag } from "@tonylb/mtw-base/ts/schema";
-import { StandardPositionData } from "./position";
+import { FacetListData } from "../../keys/abstract";
+import { PositionPayload } from "../../keys/facets/dataTypes/facet";
 import { StandardEditableData } from "@tonylb/mtw-base/ts/editable";
-import { isStandardKeyData } from "./reference";
 
 export type StandardMapData = {
     tag: 'Map';
     name?: StandardEditableData<string>;
     images?: GenericTree<SchemaTag>;
-    positions?: StandardEditableData<StandardPositionData>[];
+    positions?: FacetListData<PositionPayload>;
 } & StandardBaseData
 
 export const isStandardMapData = (arg: any): arg is StandardMapData => {
@@ -27,16 +27,7 @@ export const isStandardMapData = (arg: any): arg is StandardMapData => {
             key: 'key',
             universalKey: 'string',
             name: 'literal',
-        }),
-        (
-            !('positions' in arg) || (
-                Array.isArray(arg.positions) &&
-                arg.positions.every((position) => (
-                    'x' in position && typeof position.x === 'number' &&
-                    'y' in position && typeof position.y === 'number' &&
-                    'room' in position && isStandardKeyData(position.room)
-                ))
-            )
-        )
+            positions: 'facetList'
+        })
     )
 }

--- a/packages/mtw-wml/ts/standardize/components/map.test.ts
+++ b/packages/mtw-wml/ts/standardize/components/map.test.ts
@@ -21,7 +21,7 @@ describe('StandardMap class', () => {
         expect(testMap.key).toEqual('test')
         expect(testMap.name?.toJSON()).toEqual('Name Test')
         expect(testMap.images).toEqual([{ data: { tag: 'Image', key: "testImage" }, children: [] }])
-        expect(testMap.positions.map((position) => (position.toJSON()))).toEqual([{ room: { key: "testRoom" }, x: 100, y: 100 }])
+        expect(testMap.positions.toJSON()).toEqual([{ reference: { key: "testRoom", tag: 'Room' }, payload: { x: 100, y: 100 } }])
         expect(schemaToWML([testMap.schema])).toEqual(testSource)
     })
 
@@ -39,7 +39,7 @@ describe('StandardMap class', () => {
         expect(testMap.key).toEqual('test')
         expect(testMap.name?.toJSON()).toEqual('Name Test')
         expect(testMap.images).toEqual([{ data: { tag: 'Image', key: "testImage" }, children: [] }])
-        expect(testMap.positions.map((position) => (position.toJSON()))).toEqual([{ room: { key: "testRoom" }, x: 100, y: 100 }])
+        expect(testMap.positions.toJSON()).toEqual([{ reference: { key: "testRoom", tag: 'Room' }, payload: { x: 100, y: 100 } }])
         expect(schemaToWML([testMap.schema])).toEqual(testSource)
     })
 
@@ -49,13 +49,16 @@ describe('StandardMap class', () => {
             tag: 'Map',
             name: 'Name Test',
             images: [{ data: { tag: 'Image', key: "testImage" }, children: [] }],
-            positions: [{ room: { key: "testRoom" }, x: 10, y: 100 }]
+            positions: [{ reference: { key: "testRoom", tag: 'Room' }, payload: { x: 10, y: 100 } }]
         }
         const testMap = new StandardMap(testMapData)
         expect(testMap.key).toEqual('test')
         expect(testMap.name?.toJSON()).toEqual('Name Test')
         expect(testMap.images).toEqual([{ data: { tag: 'Image', key: "testImage" }, children: [] }])
-        expect(testMap.positions.map((position) => (position.toJSON()))).toEqual([{ room: { key: "testRoom" }, x: 10, y: 100 }])
+        expect(testMap.positions.items.map((position) => (position.toJSON()))).toEqual([{ 
+            reference: { key: "testRoom", tag: "Room", universalKey: undefined }, 
+            payload: { x: 10, y: 100 } 
+        }])
         expect(testMap.toJSON()).toEqual(testMapData)
     })
 
@@ -72,7 +75,16 @@ describe('StandardMap class', () => {
                 </Room>
             </Map>
         `))
-        expect(testMap.positions.map((position) => (position.toJSON()))).toEqual([{ room: { key: "testRoom" }, x: 100, y: 100 }, { room: { key: "testRoomTwo" }, x: 100, y: 100 }])
+        expect(testMap.positions.items.map((position) => (position.toJSON()))).toEqual([
+            { 
+                reference: { key: "testRoom", tag: "Room", universalKey: undefined }, 
+                payload: { x: 100, y: 100 } 
+            }, 
+            { 
+                reference: { key: "testRoomTwo", tag: "Room", universalKey: undefined }, 
+                payload: { x: 100, y: 100 } 
+            }
+        ])
     })
 
     it('should ignore non-position children of Room tags', () => {
@@ -86,7 +98,7 @@ describe('StandardMap class', () => {
                 </Room>
             </Map>
         `))
-        expect(testMap.positions.map((position) => (position.toJSON()))).toEqual([{ room: { key: "testRoom" }, x: 100, y: 100 }])
+        expect(testMap.positions.toJSON()).toEqual([{ reference: { key: "testRoom", tag: 'Room' }, payload: { x: 100, y: 100 } }])
     })
 
     it('should construct StandardMap from StandardMapData with missing images and positions', () => {
@@ -100,7 +112,7 @@ describe('StandardMap class', () => {
         expect(testMap.key).toEqual('test')
         expect(testMap.name?.toJSON()).toEqual('Name Test')
         expect(testMap.images).toEqual([])  // Should default to empty array
-        expect(testMap.positions).toEqual([])  // Should default to empty array
+        expect(testMap.positions.items).toEqual([])  // Should default to empty array
         
         // The JSON output should omit images and positions when empty (omission-over-empty pattern)
         const outputJSON = testMap.toJSON() as StandardMapData

--- a/packages/mtw-wml/ts/standardize/components/map.ts
+++ b/packages/mtw-wml/ts/standardize/components/map.ts
@@ -1,16 +1,16 @@
 import { excludeUndefined } from "../../lib/lists"
 import applyEdits from "../../schema/treeManipulation/applyEdits"
 import SchemaTagTree from "../../tagTree/schema"
-import { findTaggedChildren } from "../../schema/utils"
+import { findTaggedChildren, recurseIntoEditable } from "../../schema/utils"
 import { GenericTree, GenericTreeNode, treeNodeTypeguard } from "@tonylb/mtw-base/ts/genericTree"
 import { componentClassFactory, ComponentConstructorMethods } from "./component"
 import { StandardComponent, StandardComponentReferenceKey, NestedSchemaOptions } from "./baseClasses"
 import { StandardMapData } from "./dataTypes/map"
 import { ReferenceFormat } from "./utils/references"
 import { AssetUUID, ComponentUUID, SchemaTag } from "@tonylb/mtw-base/ts/schema"
-import { isSchemaMap, isSchemaRoom, isSchemaPosition } from "@tonylb/mtw-base/ts/schema/components"
+import { isSchemaMap } from "@tonylb/mtw-base/ts/schema/components"
 import { isSchemaImage } from "@tonylb/mtw-base/ts/schema/image"
-import StandardPosition, { mergeStandardPositionList, StandardPositionReplace, StandardPositionRemove, StandardPositionSimple } from "./position"
+import { PositionFacetList, StandardPositionFacet } from "../keys/facets/position"
 import StandardReference from "../keys/reference"
 import { StandardKey } from "../keys/key"
 import { StandardLiteral } from "../literal"
@@ -19,53 +19,69 @@ import { StandardExplicitParent } from "../explicit"
 /**
  * StandardMapPayload represents a Map component.
  * 
- * NOTE: We do not currently handle having items parented to Map types, and cannot really
- * `assureReferences` against `StandardPosition`. This may need to be implemented in the future
- * as part of the SchemaOrganization refactor (Phase 4.3). The `_positions` array contains
- * `StandardPosition` objects, which have a different structure than `ReferenceList`-based
- * child references used by other components like `StandardRoom`.
+ * NOTE: Positions are stored using PositionFacetList, which follows the facet pattern
+ * established by MarkFacetList in StandardExample. Each position facet contains a reference
+ * to a Room and a payload with x, y coordinates.
  */
 export class StandardMapPayload implements ComponentConstructorMethods<StandardMapData> {
     _name?: StandardLiteral;
     _images: GenericTree<SchemaTag> = [];
-    _positions: StandardPosition[] = [];
+    _positions: PositionFacetList;
     tag = 'Map' as const
 
     constructor(previous?: StandardMapPayload) {
         if (previous) {
             this._name = previous._name
             this._images = [...previous._images]
-            this._positions = [...previous.positions]
+            this._positions = previous._positions.clone()
+        } else {
+            this._positions = new PositionFacetList([])
         }
     }
 
     fromJSON(props: StandardMapData) {
         this._name = props.name ? new StandardLiteral(props.name, { tag: 'Name' }) : undefined
         this._images = props.images ?? []
-        this._positions = props.positions?.map((position) => (new StandardPosition(position))).filter(excludeUndefined) ?? []
+        this._positions = new PositionFacetList(props.positions ?? [])
     }
 
     fromSchema(node: GenericTreeNode<SchemaTag>) {
         if (treeNodeTypeguard(isSchemaMap)(node)) {
             const tagTree = new SchemaTagTree(node.children)
             const nameItem = findTaggedChildren({ children: node.children, tag: 'Name' })
-            const positionsTagTree = tagTree
-                .reordered([{ match: 'Room' }, { match: 'Position' }])
-                .prune({ not: { or: [{ match: 'Room' }, { match: 'Position' }, { match: 'Remove' }, { match: 'Replace' }, { match: 'ReplaceMatch' }, { match: 'ReplacePayload' }]}})
             const imagesTagTree = tagTree.filter({ match: 'Image' })
 
             this._name = nameItem && nameItem.length > 0 ? new StandardLiteral(nameItem, { tag: 'Name' }) : undefined
             this._images = imagesTagTree.tree
-            this._positions = positionsTagTree.tree
-                .map((position) => {
+            
+            // Parse Position facets (Room tags with Position children)
+            // findTaggedChildren handles Remove and Replace wrappers automatically
+            const roomNodes = findTaggedChildren({ children: node.children, tag: 'Room' })
+            
+            // Helper function to check if a Room node contains Position children
+            // Uses recurseIntoEditable to unwrap edit wrappers, then checks each content node for Position children
+            const hasPositionChild = (node: GenericTreeNode<SchemaTag>): boolean => {
+                return recurseIntoEditable(node, (contentNode) => {
+                    // Check if this content node has Position children
+                    const positionChildren = findTaggedChildren({ children: contentNode.children, tag: 'Position' })
+                    return positionChildren.length > 0
+                }).some(result => result)
+            }
+            
+            const parsedFacets = roomNodes
+                .filter(hasPositionChild)
+                .map(roomNode => {
+                    // Create StandardPositionFacet directly from schema - it will handle Replace/Remove/Plain dispatch
+                    // StandardPositionFacet constructor accepts GenericTree<SchemaTag> and handles parsing internally
                     try {
-                        return new StandardPosition([position])
+                        return new StandardPositionFacet([roomNode])
                     }
                     catch (e) {
                         return undefined
                     }
                 })
                 .filter(excludeUndefined)
+            this._positions = new PositionFacetList(parsedFacets)
             return
         }
         throw new Error('Schema mismatch in StandardMap constructor')
@@ -80,18 +96,31 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
             tag: 'Map',
             name: this.name?.toJSON(),
             ...(this.images.length ? { images: this.images } : {}),
-            ...(this.positions.length ? { positions: this.positions.map((position) => position.toJSON()) } : {})
+            ...(this._positions.length ? { positions: this._positions.toJSON() } : {})
         }
     }
 
     schema(key: string, universalKey?: ComponentUUID, mappings?: StandardReference[]): GenericTreeNode<SchemaTag> {
+        // Remap facets to use keys if mappings are provided (similar to nestedSchema)
+        const remappedFacets = mappings 
+            ? this._positions.items.map((facet) => facet.lookup(mappings).toFormat('key'))
+            : this._positions.items.map((facet) => facet.toFormat('key'))
+        
+        const positionSchemas = remappedFacets.map((facet) => {
+            // Use renderFacet() to generate schema with Position child included
+            // renderFacet() without referenceRender will use reference.schema and add Position
+            const result = facet.renderFacet()
+            return result.aggregatedNode ?? result.newNode
+        }).filter(excludeUndefined) as GenericTreeNode<SchemaTag>[]
+        
+        const children = [
+            ...this.name ? this.name.nestedSchema() : [],
+            ...this.images,
+            ...positionSchemas
+        ].filter(excludeUndefined)
         return {
             data: { tag: 'Map', key, uuid: universalKey },
-            children: [
-                ...this.name ? this.name.nestedSchema() : [],
-                ...this.images,
-                ...this.positions.map((position) => position.schema).filter(excludeUndefined).flat(1)
-            ]
+            children
         }
     }
 
@@ -99,22 +128,16 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
         const { key: mapKey } = options
         const mapKeyPlain = mapKey
         
-        // Process each position
-        const positionSchemas = this.positions.map((position) => {
-            // Get the position schema (Room node with Position child)
-            const positionSchema = position.schema
-            if (positionSchema.length === 0) {
-                return undefined
-            }
-            
-            const positionRoomNode = positionSchema[0]
-            if (!treeNodeTypeguard(isSchemaRoom)(positionRoomNode)) {
-                return positionRoomNode
-            }
-            
-            // NOTE: This assumes a simple (non-edit) StandardPosition schema shape. It is probably
-            //       in need of tuning for more complex edit scenarios (Remove/Replace with nested Position).
-            const roomKey = position._payload.plain.room
+        // Process each position facet
+        const positionSchemas: GenericTreeNode<SchemaTag>[] = []
+        for (const facet of this._positions.items) {
+            // Remap facet reference to use keys instead of universal keys for schema generation
+            // This ensures that when renderFacet uses reference.schema, it generates schema with keys
+            const remappedFacet = options.mappings 
+                ? facet.lookup(options.mappings).toFormat('key')
+                : facet.toFormat('key')
+            const ref = remappedFacet.reference as StandardReference
+            const roomKey = ref.standardKey
             const roomComponent = lookup(roomKey)
             
             // Check if room is parented to this map (explicit or implicit parentage)
@@ -126,30 +149,25 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
                     parent: mapKeyPlain 
                 })
                 
-                // Merge position into room schema
-                // The position schema has a Position child that needs to be added to the room's children
-                const positionChild = positionRoomNode.children.find(treeNodeTypeguard(isSchemaPosition))
+                // Render facet into room schema using renderFacet with referenceRender
+                const result = remappedFacet.renderFacet(roomNestedSchema)
                 
-                if (positionChild) {
-                    // Add Position to room's children if not already present
-                    const hasPosition = roomNestedSchema.children.some(treeNodeTypeguard(isSchemaPosition))
-                    if (!hasPosition) {
-                        return {
-                            ...roomNestedSchema,
-                            children: [
-                                positionChild,
-                                ...roomNestedSchema.children
-                            ]
-                        }
-                    }
+                if (result.aggregatedNode) {
+                    positionSchemas.push(result.aggregatedNode)
+                } else if (result.newNode) {
+                    positionSchemas.push(result.newNode)
                 }
-                
-                return roomNestedSchema
             } else {
-                // Room is not parented to map - use position-only schema
-                return positionRoomNode
+                // Room is not parented to map - render facet without referenceRender (position-only schema)
+                const result = remappedFacet.renderFacet()
+                
+                if (result.aggregatedNode) {
+                    positionSchemas.push(result.aggregatedNode)
+                } else if (result.newNode) {
+                    positionSchemas.push(result.newNode)
+                }
             }
-        }).filter(excludeUndefined)
+        }
         
         return {
             data: { tag: 'Map', key: mapKey.key ?? '', uuid: mapKey.universalKey },
@@ -165,7 +183,8 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
         const returnValue = new StandardMapPayload()
         returnValue._name = this._name && incoming._name ? this._name.merge(incoming._name) : this._name ?? incoming._name,
         returnValue._images = applyEdits([...this.images, ...incoming.images])
-        returnValue._positions = mergeStandardPositionList(this.positions, incoming.positions)
+        const mergedPositions = this._positions.merge(incoming._positions)
+        returnValue._positions = mergedPositions ?? new PositionFacetList([])
         return returnValue as this
     }
 
@@ -175,14 +194,11 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
 
     referencedKeys(): StandardComponentReferenceKey[] {
         // Extract Position references (for Rooms)
-        const positionReferences = this.positions.map((position ) => {
-            if (position._payload instanceof StandardPositionSimple || position._payload instanceof StandardPositionReplace) {
-                // Positions always reference rooms
-                const positionReference = new StandardReference(position._payload.room, 'Room')
-                return [{ referenceType: 'Position' as const, reference: positionReference }]
-            }
-            return []
-        }).flat(1)
+        const positionReferences = this._positions.items.map((facet) => {
+            // Facets are structural relationships with associated payload data
+            const ref = facet.reference as StandardReference
+            return { referenceType: 'Position' as const, reference: ref }
+        })
         
         // Extract Image references from _images schema nodes
         const imageReferences = this._images
@@ -205,11 +221,7 @@ export class StandardMapPayload implements ComponentConstructorMethods<StandardM
 
     remapReferences(props: { mappings: StandardReference[]; mapTo: ReferenceFormat }): this {
         const returnValue = new StandardMapPayload(this)
-        // const mapReference = mapReferenceToFormat(props.mappings, props.mapTo === 'uuid' ? 'universal' : 'key')
-        //
-        // After refactoring Position as StandardPosition class, we will need to
-        // remap those references here
-        //
+        returnValue._positions = this._positions.lookup(props.mappings).toFormat(props.mapTo)
         return returnValue as this
     }
 

--- a/packages/mtw-wml/ts/standardize/index.test.ts
+++ b/packages/mtw-wml/ts/standardize/index.test.ts
@@ -1000,12 +1000,8 @@ describe('StandardForm', () => {
                 <Map uuid=(testMap) key=(testMap)>
                     <Name>Test map</Name>
                     <Image key=(mapBackground) />
-                    <Room uuid=(testRoomOne) key=(testRoomOne)>
-                        <Position x="0" y="0" />
-                    </Room>
-                    <Room uuid=(testRoomTwo) key=(testRoomTwo)>
-                        <Position x="-100" y="0" />
-                    </Room>
+                    <Room key=(testRoomOne)><Position x="0" y="0" /></Room>
+                    <Room key=(testRoomTwo)><Position x="-100" y="0" /></Room>
                 </Map>
             </Asset>
         `))

--- a/packages/mtw-wml/ts/standardize/keys/facets/position.ts
+++ b/packages/mtw-wml/ts/standardize/keys/facets/position.ts
@@ -160,6 +160,10 @@ export class PositionFacetPayload {
         return new PositionFacetPayload(inverted);
     }
 
+    get plain(): StandardPositionPayloadBase | undefined {
+        return this._payload.plain;
+    }
+
     // FacetPayloadBase method: parse from schema
     fromSchema(node: GenericTree<SchemaTag>, reference: StandardReference): PositionPayloadType {
         if (node.length === 0) {

--- a/packages/mtw-wml/ts/standardize/keys/facets/position.ts
+++ b/packages/mtw-wml/ts/standardize/keys/facets/position.ts
@@ -10,7 +10,7 @@ import { isSchemaPosition, isSchemaRoom } from "@tonylb/mtw-base/ts/schema/compo
 import { isSchemaRemove } from "@tonylb/mtw-base/ts/schema/edit";
 import { facetClassFactory } from './facetFactory';
 import { isSchemaTreeNode, treeFromWML } from "../../../schema";
-import { transformNestedChildren } from "../../../schema/utils";
+import { transformNestedChildren, findTaggedChildren } from "../../../schema/utils";
 
 //
 // StandardPositionPayloadBase holds the contents for a simple PositionPayload
@@ -461,10 +461,16 @@ export function createPositionFacetPayload(arg: any): PositionFacetPayload {
         const schema = factoryProps;
         if (schema.length > 0) {
             const firstElement = schema[0];
-            // If first element is a Room tag, extract its children (which contain the Position tag or Remove/Replace wrappers)
+            // If first element is a Room tag, extract only Position children (and Remove/Replace wrappers containing Position)
             if (treeNodeTypeguard(isSchemaRoom)(firstElement)) {
-                // Extract Position children from Room tag - this is what PositionEditableClass expects
-                return new PositionFacetPayload(firstElement.children);
+                // Extract only Position children from Room tag - findTaggedChildren handles Remove/Replace wrappers
+                // This ensures payloadFactory receives a tree where the first element is a Position tag (or Remove/Replace wrapper)
+                const positionChildren = findTaggedChildren({ children: firstElement.children, tag: 'Position' });
+                if (positionChildren.length === 0) {
+                    throw new Error('Room node does not contain Position children');
+                }
+                // PositionEditableClass expects a tree where Position tags (or their wrappers) are the top-level elements
+                return new PositionFacetPayload(positionChildren);
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `Map` positions to a facet-based structure for consistency with other keyed relationships.
> 
> - Core: `StandardMap` now uses `PositionFacetList` with `StandardPositionFacet`; updates parsing (`fromSchema`), JSON (`toJSON`), schema rendering (`schema`, `nestedSchema`), merging, reference remapping, and emptiness checks
> - Data types: `StandardMapData.positions` now `FacetListData<PositionPayload>`; validators updated
> - Client: Map controllers, D3 tree, and layers read/write via `positions.items`, use facet `reference` and `payload.plain`, skip `PositionRemoveClass`; stability updates replace facets in-place; room addition creates `StandardPositionFacet`
> - Utilities: Exit extraction reads room IDs from position facets
> - Lambda: `componentRender` aggregates map rooms from facet references and serializes positions via `merged.positions.toJSON()`
> - Tests/snapshots: Updated to expect facet-based positions and key-only room references in map schemas
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cc61e56843d3fce7b58a3e31aeeb1efc8a713b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->