### PR TITLE
Iss7094 implement coordination events in mtw interfaces

### DIFF
--- a/AGENT.development.md
+++ b/AGENT.development.md
@@ -276,6 +276,15 @@ The following migrations must be completed in this specific order due to depende
 
 **Future consideration**: It may make sense to evaluate whether we still use `.address` for assets at all. If zone is fully expressed in metadata and no longer implied by directory layout, code that relies on `assetWorkspace.address` or similar may be redundant or simplifiable.
 
+#### Coordination events: remove mtw.coordination EventBridge, localize API handling
+**Status**: Future task (not part of current serialization refactor)
+
+**Context**: Coordination commands (Apply Edit, Move Asset, Purge Asset, Canonize/Decanonize Asset, Create Snapshot) are today sent in-process via the messageBus with `dataSourceKey: 'internal'`. Nothing publishes `mtw.coordination` events to EventBridge; the EventBridge serializer and Assets' subscription to `mtw.coordination` (e.g. Remove Asset) are legacy from an earlier pattern.
+
+**Future option worth pursuing**: Remove `mtw.coordination` from EventBridge entirely and treat coordination as purely internal API handling. Each lambda would be explicitly responsible for the structure of its own API handling; no shared EventBridge coordination channel. This would mean removing the CoordinationEventSerializer registration for EventBridge, removing Assets' subscription to `mtw.coordination` (or repurposing Remove Asset if needed), and keeping coordination types and handling local to the lambdas that use them.
+
+**Recommendation**: Documented here as a possible future shift. Not part of the current DataSource serialization boundary refactor (see `packages/mtw-lambda-patterns/ts/dataSource/AGENT.serializationRefactor.planning.md`). Revisit when prioritizing cleanup of unused EventBridge paths or when redefining lambda API boundaries.
+
 ---
 
 ## Cross-Phase Considerations

--- a/lambda/wml/app.ts
+++ b/lambda/wml/app.ts
@@ -4,7 +4,7 @@ import { S3Client } from "@aws-sdk/client-s3";
 import messageBus from "./messageBus";
 import type { StreamingEventMessage } from "./messageBus/baseClasses";
 import { extractReturnValue } from "./returnValue/index";
-import { CoordinationEventExternal, CoordinationEventSerializer } from './dataSource/coordinationSerializer';
+import { CoordinationEventSerializer } from '@tonylb/mtw-interfaces/ts/eventBridge/coordination';
 import { sendApplyEdit, sendMoveAsset, sendPurgeAsset } from './dataSource/subscribedEvents';
 import { sendInitializeSubscription } from './dataSource/initSubscription';
 import { fromEventBridgeFormat } from '@tonylb/mtw-lambda-patterns/ts/dataSource/formatTransform';

--- a/lambda/wml/dataSource/moveAsset/index.test.ts
+++ b/lambda/wml/dataSource/moveAsset/index.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../utilities/mockableTime', () => ({
 
 import { now } from '../../utilities/mockableTime'
 import { moveAsset } from './index'
-import { isMoveAssetRequest, MoveAssetRequest } from '../coordinationSerializer'
+import { isMoveAssetRequest, MoveAssetRequest } from '@tonylb/mtw-interfaces/ts/eventBridge/coordination'
 
 const mockChangeZone = changeZone as jest.MockedFunction<typeof changeZone>
 const mockNow = now as jest.MockedFunction<typeof now>

--- a/lambda/wml/dataSource/moveAsset/index.ts
+++ b/lambda/wml/dataSource/moveAsset/index.ts
@@ -5,7 +5,7 @@
  * changeZone operation, which manages S3 tags, manifests, and self-repair.
  */
 
-import { MoveAssetRequest } from "../coordinationSerializer"
+import { MoveAssetRequest } from '@tonylb/mtw-interfaces/ts/eventBridge/coordination'
 import { AssetUUID } from "@tonylb/mtw-base/ts/schema"
 import { changeZone } from "../../s3Storage"
 import { now } from "../../utilities/mockableTime"

--- a/lambda/wml/dataSource/mtw-wml.test.ts
+++ b/lambda/wml/dataSource/mtw-wml.test.ts
@@ -1,7 +1,7 @@
 import { wmlDataSource } from './index'
 import { WMLEventSerializer } from '@tonylb/mtw-interfaces/ts/eventBridge/wml'
 import { moveAsset } from './moveAsset'
-import { MoveAssetRequest, isApplyEditRequest } from './coordinationSerializer'
+import { MoveAssetRequest, isApplyEditRequest } from '@tonylb/mtw-interfaces/ts/eventBridge/coordination'
 import { initializePrimitives } from './initializePrimitives'
 import { createManualSnapshot } from '../s3Storage/manifest/orchestration'
 import AssetWorkspace from '../s3Storage/AssetWorkspace'

--- a/lambda/wml/dataSource/mtw-wml.ts
+++ b/lambda/wml/dataSource/mtw-wml.ts
@@ -4,7 +4,7 @@ import { WMLEventSerializer, WMLEventUpdate, WMLEventExternal } from '@tonylb/mt
 import { moveAsset } from './moveAsset'
 import { applyEdit } from './applyEdit'
 import { purgeAsset } from './purgeAsset'
-import { CoordinationEventUpdate, isCoordinationCanonizeEvent, isCoordinationDecanonizeEvent, MoveAssetRequest, ApplyEditRequest, CreateSnapshotRequest, PurgeAssetRequest } from './coordinationSerializer'
+import { CoordinationEventUpdate, isCoordinationCanonizeEvent, isCoordinationDecanonizeEvent, MoveAssetRequest, ApplyEditRequest, CreateSnapshotRequest, PurgeAssetRequest } from '@tonylb/mtw-interfaces/ts/eventBridge/coordination'
 import { DiagnosticsEventUpdate, isS3StructureFindingEvent } from '@tonylb/mtw-interfaces/ts/eventBridge/diagnostics'
 import { isSchemaAssetUUID, AssetUUID } from "@tonylb/mtw-base/ts/schema"
 import { StandardForm } from '@tonylb/mtw-wml/ts/standardize'

--- a/lambda/wml/dataSource/subscribedEvents.ts
+++ b/lambda/wml/dataSource/subscribedEvents.ts
@@ -13,7 +13,7 @@ import {
     MoveAssetRequest,
     PurgeAssetRequest,
     CreateSnapshotRequest,
-} from './coordinationSerializer'
+} from '@tonylb/mtw-interfaces/ts/eventBridge/coordination'
 import type { DiagnosticsEventUpdate } from '@tonylb/mtw-interfaces/ts/eventBridge/diagnostics'
 import type { StreamingEventMessage } from '../messageBus/baseClasses'
 

--- a/packages/mtw-interfaces/ts/eventBridge/AGENT.implementation.md
+++ b/packages/mtw-interfaces/ts/eventBridge/AGENT.implementation.md
@@ -27,8 +27,8 @@ export const isDataSourceEventType1 = (event: any): event is EventType1 => { ...
 
 // Serializer implementing the interface
 export class DataSourceEventSerializer implements DataSourceEventSerializer<DataSourceEventUpdate, DataSourceEventExternal> {
-    serialize(params: { dataSourceKey: string; streamKey: string; update: DataSourceEventUpdate }): DataSourceEventExternal
-    deserialize(params: { dataSourceKey: string; streamKey: string; externalUpdate: DataSourceEventExternal }): DataSourceEventUpdate | null
+    serialize(params: { content: DataSourceEventUpdate; header: StreamingEventHeader }): DataSourceEventExternal
+    deserialize(params: { content: DataSourceEventExternal; header: StreamingEventHeader }): DataSourceEventUpdate | null
 }
 ```
 
@@ -41,17 +41,15 @@ All serializers must implement `DataSourceEventSerializer<UpdatePayload, Externa
 ```typescript
 export class MyEventSerializer implements DataSourceEventSerializer<MyEventUpdate, MyEventExternal> {
     serialize(params: {
-        dataSourceKey: string;
-        streamKey: string;
-        update: MyEventUpdate;
+        content: MyEventUpdate;
+        header: StreamingEventHeader;
     }): MyEventExternal {
         // Convert internal format to external format
     }
-    
+
     deserialize(params: {
-        dataSourceKey: string;
-        streamKey: string;
-        externalUpdate: MyEventExternal;
+        content: MyEventExternal;
+        header: StreamingEventHeader;
     }): MyEventUpdate | null {
         // Convert external format to internal format
     }
@@ -81,7 +79,7 @@ For envelope unions and payload purity rules, see [mtw-lambda-patterns DataSourc
 
 ```typescript
 // Good: Graceful error handling
-deserialize(params: { ... }): MyEventUpdate | null {
+deserialize(params: { content: MyEventExternal; header: StreamingEventHeader }): MyEventUpdate | null {
     try {
         // Parse external event
         return parsedEvent
@@ -92,7 +90,7 @@ deserialize(params: { ... }): MyEventUpdate | null {
 }
 
 // Good: Validation with clear error messages
-serialize(params: { ... }): MyEventExternal {
+serialize(params: { content: MyEventUpdate; header: StreamingEventHeader }): MyEventExternal {
     if (!isValidEvent(params.content)) {
         throw new Error(`Invalid event type: ${JSON.stringify(params.content)}`)
     }
@@ -175,7 +173,7 @@ Pattern docs do not list every call-site. Search yields the live inventory.
 
 | What to find | Grep pattern | Notes |
 |--------------|--------------|-------|
-| Serializers | `implements DataSourceEventSerializer` | In `packages/mtw-interfaces/ts/eventBridge/**` and `lambda/wml/dataSource/coordinationSerializer.ts` |
+| Serializers | `implements DataSourceEventSerializer` | In `packages/mtw-interfaces/ts/eventBridge/**` |
 | EventBridge contract layout | Directory `packages/mtw-interfaces/ts/eventBridge/` | One directory per data source |
 | Lambda envelope unions | `IncomingEvent` | Envelope unions for `receiveEvents` (e.g. `AssetsIncomingEvent`, `LibraryIncomingEvent`) |
 | Lambda DataSource keys | `dataSourceKey: 'mtw\.` in `lambda/` | DataSource instantiations |

--- a/packages/mtw-interfaces/ts/eventBridge/coordination/coordination.test.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/coordination/coordination.test.ts
@@ -4,7 +4,7 @@ import {
     type CoordinationEventExternal,
     type ApplyEditRequest,
     type MoveAssetRequest
-} from './coordinationSerializer'
+} from './index'
 import type { StreamingEventHeader } from '@tonylb/mtw-lambda-patterns/ts/dataSource/baseClasses'
 
 const dataSourceKey = 'mtw.coordination'

--- a/packages/mtw-interfaces/ts/eventBridge/coordination/index.ts
+++ b/packages/mtw-interfaces/ts/eventBridge/coordination/index.ts
@@ -1,7 +1,15 @@
+// Coordination Data Source Event Contracts
+//
+// Event types, type guards, and serializer for mtw.coordination (Apply Edit, Move Asset, etc.).
+// Migrated from lambda/wml/dataSource/coordinationSerializer.ts
+
 import { Zone } from '@tonylb/mtw-interfaces/ts/baseClasses'
 import { DataSourceEventSerializer, ResolvedStreamingEnvelope, StreamingEventHeader } from '@tonylb/mtw-lambda-patterns/ts/dataSource/baseClasses'
 
+//
 // Internal types for coordination events (no type; discrimination by header)
+//
+
 export type CoordinationCanonizeEvent = Record<string, never>
 
 export type CoordinationDecanonizeEvent = Record<string, never>
@@ -40,7 +48,10 @@ export const COORDINATION_EVENT_TYPES = new Set<string>([
     'Purge Asset'
 ])
 
-// External types for coordination events (same as internal since they're hand-created)
+//
+// External types for coordination events (EventBridge format)
+//
+
 export type CoordinationCanonizeEventExternal = {
     type: 'Canonize Asset';
 }
@@ -75,15 +86,18 @@ export type PurgeAssetRequestExternal = {
     requireExists?: boolean;
 }
 
-export type CoordinationEventExternal = 
-    | CoordinationCanonizeEventExternal 
-    | CoordinationDecanonizeEventExternal 
+export type CoordinationEventExternal =
+    | CoordinationCanonizeEventExternal
+    | CoordinationDecanonizeEventExternal
     | MoveAssetRequestExternal
     | ApplyEditRequestExternal
     | CreateSnapshotRequestExternal
     | PurgeAssetRequestExternal
 
+//
 // Type guards (shape-based)
+//
+
 export const isMoveAssetRequest = (event: any): event is MoveAssetRequest => {
     return event &&
         typeof event === 'object' &&
@@ -119,8 +133,8 @@ export const isPurgeAssetRequest = (event: any): event is PurgeAssetRequest => {
 }
 
 export const isCoordinationEventUpdate = (event: unknown): event is CoordinationEventUpdate => {
-    return isCoordinationCanonizeEvent(event) || 
-           isCoordinationDecanonizeEvent(event) || 
+    return isCoordinationCanonizeEvent(event) ||
+           isCoordinationDecanonizeEvent(event) ||
            isMoveAssetRequest(event) ||
            isApplyEditRequest(event) ||
            isCreateSnapshotRequest(event) ||
@@ -129,12 +143,12 @@ export const isCoordinationEventUpdate = (event: unknown): event is Coordination
 
 /**
  * Serializer/Deserializer for coordination format events
- * 
- * This handles the conversion between:
+ *
+ * Handles conversion between:
  * - Internal event objects (for messageBus communication)
  * - External event objects (for EventBridge transmission)
- * 
- * Coordination events are hand-created and pass through as structured data
+ *
+ * Coordination events are hand-created and pass through as structured data.
  */
 
 // Serialize/deserialize params - use ResolvedStreamingEnvelope so header discriminates content shape
@@ -171,8 +185,7 @@ const isDecanonizeAssetCoordinationDeserializeParams = (p: CoordinationDeseriali
 
 export class CoordinationEventSerializer implements DataSourceEventSerializer<CoordinationEventUpdate, CoordinationEventExternal> {
     /**
-     * Serialize an internal event to external format
-     * for EventBridge transmission
+     * Serialize an internal event to external format for EventBridge transmission
      */
     serialize(params: CoordinationSerializeParams): CoordinationEventExternal {
         if (isMoveAssetCoordinationSerializeParams(params)) {
@@ -216,8 +229,7 @@ export class CoordinationEventSerializer implements DataSourceEventSerializer<Co
     }
 
     /**
-     * Deserialize an external event back to internal format
-     * for messageBus processing
+     * Deserialize an external event back to internal format for messageBus processing
      */
     deserialize(params: CoordinationDeserializeParams): CoordinationEventUpdate | null {
         if (isCanonizeAssetCoordinationDeserializeParams(params)) {
@@ -256,7 +268,7 @@ export class CoordinationEventSerializer implements DataSourceEventSerializer<Co
         }
         return null
     }
-    
+
     // Note: serializeSnapshot and deserializeSnapshot are not implemented
     // as coordination events are for a non-replayable data source that doesn't use snapshots
 }

--- a/packages/mtw-lambda-patterns/ts/dataSource/AGENT.serializationRefactor.planning.md
+++ b/packages/mtw-lambda-patterns/ts/dataSource/AGENT.serializationRefactor.planning.md
@@ -196,13 +196,20 @@ Use the checkboxes and "Status" lines to track progress. Add GitHub issue number
 
 ### 5. Event contracts in mtw-interfaces
 
-- [ ] **5a. Move Coordination event contracts to mtw-interfaces**  
+- [x] **5a. Move Coordination event contracts to mtw-interfaces**  
   - **What**: Move Coordination event types (e.g. `CoordinationCanonizeEventExternal`, `CoordinationEventExternal`, etc.) and `CoordinationEventSerializer` from `lambda/wml/dataSource/coordinationSerializer.ts` to a suitable module under `packages/mtw-interfaces/ts/eventBridge/` (e.g. `coordination` or under `wml` if that fits). Update lambda/wml to import from `@tonylb/mtw-interfaces/ts/eventBridge/...`.  
-  - **Status**:  
-  - **Depends on**: None (can be done independently; may want a single PR with 5b).  
+  - **Status**: Done. Coordination types and CoordinationEventSerializer live in `@tonylb/mtw-interfaces/ts/eventBridge/coordination`; lambda/wml imports from there. `lambda/wml/dataSource/coordinationSerializer.ts` and its test were removed.  
+  - **Depends on**: None (can be done independently; may want a single PR with 5c).  
   - **Files**: New or existing file in mtw-interfaces; `lambda/wml/dataSource/coordinationSerializer.ts` (delete or re-export); `lambda/wml/app.ts`, `lambda/wml/dataSource/mtw-wml.ts`, tests.
 
-- [ ] **5b. Update EventBridge AGENT.implementation.md contract**  
+- [x] **5b. Document future option: remove mtw.coordination EventBridge, localize coordination as internal-only**  
+  - **What**: In [AGENT.development.md](../../../../AGENT.development.md) (or equivalent master roadmap), add a short "Future task" note: the possible shift to remove `mtw.coordination` EventBridge events entirely and treat coordination (Apply Edit, Move Asset, Purge Asset, etc.) as purely internal API handling—each lambda responsible for the structure of its own API handling, no shared EventBridge coordination channel. This is a future option worth pursuing, not part of the current serialization refactor.  
+  - **Why**: Captures the option so it can be revisited; keeps current plan (5a) reversible and avoids the refactor scope expanding into coordination removal.  
+  - **Status**: Done. Documented in AGENT.development.md under "Coordination events: remove mtw.coordination EventBridge, localize API handling".  
+  - **Depends on**: None.  
+  - **Files**: `AGENT.development.md` (add subsection or bullet under Future Development Considerations).
+
+- [ ] **5c. Update EventBridge AGENT.implementation.md contract**  
   - **What**: Fix the documented serializer contract in `packages/mtw-interfaces/ts/eventBridge/AGENT.implementation.md` so the only signature shown is `{ content, header }` (remove the old `dataSourceKey`, `streamKey`, `update`/`externalUpdate` code blocks).  
   - **Status**:  
   - **Depends on**: None.
@@ -231,7 +238,7 @@ Use the checkboxes and "Status" lines to track progress. Add GitHub issue number
 
 ## Suggested ordering
 
-- **Early / quick wins (header authoritative first)**: 1a (Ephemera path), 2a (matchEvent on header), 3a (same as 2a), 3b (toEventBridgeFormat uses header for type), 3d (tests). Then 5a+5b (Coordination move + doc fix). Doing 3 before 4–7 establishes the authority rule with no new abstractions; publisher and docs can follow.
+- **Early / quick wins (header authoritative first)**: 1a (Ephemera path), 2a (matchEvent on header), 3a (same as 2a), 3b (toEventBridgeFormat uses header for type), 3d (tests). Then 5a+5c (Coordination move + doc fix). Doing 3 before 4–7 establishes the authority rule with no new abstractions; publisher and docs can follow.
 - **Publisher refactor**: 4a -> 4b -> 4c (introduce publisher, then DataSource, then initialize). **Subscription lambda (4d, 4e)**: 4d (matchEvent on header) can be done once 3e/3f/3g are in place; 4e (EventBridge-to-WebSocket via wireFormatsFromCoreFormat) is a natural follow-on now that the publisher produces all wire formats—subscription handlers can use the same abstraction for the client message instead of hand-building from CoreExternalFormat.
 - **Extended-header cleanup**: 6a (generic extended-header merge for WebSocketFormat) after 4f.
 - **Docs**: 7a and 7b can proceed in parallel with any of the above.

--- a/packages/mtw-lambda-patterns/ts/dataSource/AGENT.serializationRefactor.planning.md
+++ b/packages/mtw-lambda-patterns/ts/dataSource/AGENT.serializationRefactor.planning.md
@@ -209,9 +209,9 @@ Use the checkboxes and "Status" lines to track progress. Add GitHub issue number
   - **Depends on**: None.  
   - **Files**: `AGENT.development.md` (add subsection or bullet under Future Development Considerations).
 
-- [ ] **5c. Update EventBridge AGENT.implementation.md contract**  
+- [x] **5c. Update EventBridge AGENT.implementation.md contract**  
   - **What**: Fix the documented serializer contract in `packages/mtw-interfaces/ts/eventBridge/AGENT.implementation.md` so the only signature shown is `{ content, header }` (remove the old `dataSourceKey`, `streamKey`, `update`/`externalUpdate` code blocks).  
-  - **Status**:  
+  - **Status**: Done. All serializer code blocks now use `{ content, header }`; discovery table no longer references removed coordinationSerializer path.  
   - **Depends on**: None.
 
 ### 6. Generic extended-header merge for WebSocketFormat


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared event contract/serializer code used for runtime deserialization in the WML lambda; import/contract mismatches would break event handling, though the change is largely a relocation with tests updated.
> 
> **Overview**
> Coordination EventBridge contracts (`Apply Edit`, `Move Asset`, `Purge Asset`, `Canonize/Decanonize`, `Create Snapshot`) are **moved out of `lambda/wml` into `packages/mtw-interfaces/ts/eventBridge/coordination`**, including the `CoordinationEventSerializer`, type guards, and tests; WML lambda code and tests are updated to import from the shared interfaces module.
> 
> Documentation is updated to reflect the serializer `{ content, header }` signature and to record a *future* cleanup option to remove `mtw.coordination` from EventBridge entirely and treat coordination as internal-only API handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6b42e0872ea8f664df503565c060d078edb6a1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->